### PR TITLE
DASH-26 provide specific admin roles as part of the extension

### DIFF
--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -17,17 +17,11 @@ component {
 	}
 
 	private void function _setupPermissionsAndRoles( required struct settings ) {
-		settings.adminPermissions.adminDashboards = [ "navigate", "read", "add", "edit", "clone", "delete" ];
+		settings.adminPermissions.adminDashboards = [ "navigate", "read", "add", "edit", "clone", "delete", "fullaccess" ];
 
-		if ( IsArray( settings.adminRoles.sysadmin ?: "" ) ) {
-			ArrayAppend( settings.adminRoles.sysadmin, "adminDashboards.*" );
-		}
-		if ( IsArray( settings.adminRoles.contentadmin ?: "" ) ) {
-			ArrayAppend( settings.adminRoles.contentadmin, "adminDashboards.*" );
-		}
-		if ( IsArray( settings.adminRoles.contenteditor ?: "" ) ) {
-			ArrayAppend( settings.adminRoles.contenteditor, "adminDashboards.*" );
-		}
+		settings.adminRoles.dashBoardSuperAdmin = [ "adminDashboards.*" ];
+		settings.adminRoles.dashBoardAdmin      = [ "adminDashboards.*", "!adminDashboards.fullaccess" ];
+		settings.adminRoles.dashBoardUser       = [ "adminDashboards.navigate", "adminDashboards.read" ];
 	}
 
 // PRIVATE HELPERS

--- a/i18n/roles.properties
+++ b/i18n/roles.properties
@@ -1,0 +1,13 @@
+rolegroup.admindashboards.title=Admin dashboards
+
+dashBoardSuperAdmin.title=Admin dashboard super admin
+dashBoardSuperAdmin.description=Can access, create and manage admin dashboards, <strong>including dashboards owned by other users</strong>
+dashBoardSuperAdmin.group=admindashboards
+
+dashBoardAdmin.title=Admin dashboard administrator
+dashBoardAdmin.description=Can access, create and manage admin dashboards. Limited to dashboards created by them or shared with them by other users.
+dashBoardAdmin.group=admindashboards
+
+dashBoardUser.title=Admin dashboard user
+dashBoardUser.description=Can view admin dashboards created by other users
+dashBoardUser.group=admindashboards

--- a/i18n/roles.properties
+++ b/i18n/roles.properties
@@ -9,5 +9,5 @@ dashBoardAdmin.description=Can access, create and manage admin dashboards. Limit
 dashBoardAdmin.group=admindashboards
 
 dashBoardUser.title=Admin dashboard user
-dashBoardUser.description=Can view admin dashboards created by other users
+dashBoardUser.description=Can view admin dashboards created and shared by other users
 dashBoardUser.group=admindashboards

--- a/services/AdminDashboardService.cfc
+++ b/services/AdminDashboardService.cfc
@@ -72,7 +72,7 @@ component {
 	}
 
 	public boolean function hasFullAccess( required string adminUserId ) {
-		return permissionService.userHasAssignedRoles( userId=arguments.adminUserId, roles=[ "sysadmin" ] );
+		return permissionService.hasPermission( permissionKey="adminDashboards.fullaccess", userId=arguments.adminUserId );
 	}
 
 // PRIVATE HELPERS


### PR DESCRIPTION
Rather than relying on common roles that may or may not exist in other systems, provide our roles.
    
Within that, provide a tier that has "super" privileges which means being able to edit other people's dashboards. This allows full control over who can do what, rather than just assuming all 'sysadmin' role users can do this (sysadmin role may not exist).