### PR TITLE
DASH-68 admin add widget flow select widget step search bar styling issue

### DIFF
--- a/assets/css/admin/specific/webflow/adminDashboardsAddWidget/selectWidget/selectWidget.less
+++ b/assets/css/admin/specific/webflow/adminDashboardsAddWidget/selectWidget/selectWidget.less
@@ -1,6 +1,7 @@
 .presidecms {
 
 	.admin-dashboards-widgets-header {
+		margin-bottom: 20px;
 
 		.widgets-search-container {
 			position : relative;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves spacing in the Add Widget "Select Widget" step.
> 
> - Adds `margin-bottom: 20px;` to `admin-dashboards-widgets-header` in `selectWidget.less` to fix search bar/filter layout spacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f616ca53d321275322cb11d084f55db7247a4291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->