### PR TITLE
DASH-69: Add dashboard selector static cutup

### DIFF
--- a/assets/css/admin/specific/admindashboards/dashboard-selector.less
+++ b/assets/css/admin/specific/admindashboards/dashboard-selector.less
@@ -77,6 +77,4 @@
 			}
 		}
 	}
-
-	// .presidecms .preside-theme .dropdown-menu > li
 }

--- a/assets/css/admin/specific/admindashboards/dashboard-selector.less
+++ b/assets/css/admin/specific/admindashboards/dashboard-selector.less
@@ -1,0 +1,82 @@
+.dashboard-selector {
+	display     : flex;
+	align-items : center;
+	gap         : 12px;
+
+	&-label {
+		font-weight : var( --font-weight-bold, 600 );
+	}
+
+	.dropdown {
+
+		> .btn {
+			min-width        : 255px;
+			background-color : transparent !important;
+			display          : flex;
+			justify-content  : space-between;
+			align-items      : center;
+
+			&:focus:hover,
+			&:active:hover {
+				background-color : var( --color-neutral-5, #f6f7f5 ) !important;
+			}
+		}
+
+		.dropdown-menu-dashboard {
+			padding : 0;
+			width   : 100%;
+
+			> li {
+				margin        : 0;
+				border-bottom : 1px solid var( --color-neutral-20, #D2D3D5 );
+
+				&:last-child {
+					border-bottom : none;
+				}
+
+				h6 {
+					color         : var( --color-neutral-40, #A4A7AA );
+					display       : flex;
+					gap           : 6px;
+					padding       : 0 16px;
+					margin-top    : 20px;
+					margin-bottom : 7px;
+
+					.fa {
+						color: var( --color-secondary-100, #1DD3B0 );
+					}
+				}
+
+				ul {
+					margin     : 0;
+					padding    : 0;
+					list-style : none;
+				}
+
+				.dashboard-list-item {
+
+					a {
+						flex-direction : column;
+						align-items    : flex-start;
+						padding        : 10px 16px;
+
+						&:hover,
+						&:focus {
+							background-color : var( --color-neutral-5, #f6f7f5 );
+						}
+					}
+
+					.dashboard-title {
+						color: var( --color-neutral-100, #21262B );
+					}
+
+					.dashboard-subtitle {
+						color: var( --color-neutral-60, #757B80 );
+					}
+				}
+			}
+		}
+	}
+
+	// .presidecms .preside-theme .dropdown-menu > li
+}

--- a/assets/css/admin/specific/webflow/adminDashboardsAddWidget/selectWidget/selectWidget.less
+++ b/assets/css/admin/specific/webflow/adminDashboardsAddWidget/selectWidget/selectWidget.less
@@ -101,6 +101,10 @@
 
 				.widget-item-content{
 
+					.widget-item-precontent {
+						margin-bottom: 2px;
+					}
+
 					.widget-item-title {
 						margin-bottom: 0;
 						font-weight: 600;

--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -4,6 +4,7 @@ component {
 		var conf     = arguments.config;
 		var settings = conf.settings ?: {};
 
+		_setupFeatures( settings );
 		_setupEnums( settings );
 		_setupPermissionsAndRoles( settings );
 		_setupInterceptors( conf );
@@ -15,10 +16,15 @@ component {
 		};
 	}
 
+	private void function _setupFeatures( required struct settings ) {
+		settings.features.adminDashboards = { enabled=true };
+	}
+
 	private void function _setupEnums( settings ) {
 		settings.enum.adminDashboardViewAccess = [ "private", "public", "specific" ];
 		settings.enum.adminDashboardEditAccess = [ "private", "specific" ];
 		settings.enum.adminDashboardWidgetType = [ "gallery", "scratch", "import" ];
+		settings.enum.adminDashboardContexts   = settings.enum.adminDashboardContexts ?: [];
 	}
 
 	private void function _setupPermissionsAndRoles( required struct settings ) {

--- a/forms/preside-objects/admin_dashboard.xml
+++ b/forms/preside-objects/admin_dashboard.xml
@@ -4,6 +4,7 @@
 		<fieldset id="main">
 			<field binding="admin_dashboard.name"             sortOrder="10" />
 			<field binding="admin_dashboard.description"      sortOrder="20" />
+			<field binding="admin_dashboard.contexts"         sortOrder="30" control="enumSelect" enum="adminDashboardContexts" multiple="true" />
 		</fieldset>
 	</tab>
 </form>

--- a/forms/preside-objects/admin_dashboard.xml
+++ b/forms/preside-objects/admin_dashboard.xml
@@ -2,6 +2,9 @@
 <form i18nBaseUri="preside-objects.admin_dashboard:">
 	<tab id="main">
 		<fieldset id="main">
+			<field name="redirectObjectName" control="hidden" />
+			<field name="redirectRecordId"   control="hidden" />
+
 			<field binding="admin_dashboard.name"             sortOrder="10" />
 			<field binding="admin_dashboard.description"      sortOrder="20" />
 			<field binding="admin_dashboard.contexts"         sortOrder="30" control="enumSelect" enum="adminDashboardContexts" multiple="true" />

--- a/forms/preside-objects/admin_dashboard/sharing.xml
+++ b/forms/preside-objects/admin_dashboard/sharing.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form i18nBaseUri="preside-objects.admin_dashboard:">
 	<tab id="main">
+		<fieldset id="main">
+			<field name="redirectObjectName" control="hidden" />
+			<field name="redirectRecordId"   control="hidden" />
+		</fieldset>
 		<fieldset id="view_permissions">
 			<field binding="admin_dashboard.view_access" sortOrder="10" control="enumRadioList" />
 			<field binding="admin_dashboard.view_groups" sortOrder="20" />

--- a/handlers/admin/AdminDashboards.cfc
+++ b/handlers/admin/AdminDashboards.cfc
@@ -138,7 +138,12 @@ component extends="preside.system.base.AdminHandler" {
 		var dashboardId  = args.dashboardId ?: "";
 		var allowEditing = isTrue( args.allowEditing ?: "" );
 		var action       = ListLast( rc.event ?: "", "." );
-		var dashboard    = widgetService.renderUserGeneratedGridDashboard( dashboardId=dashboardId, allowEditing=allowEditing, showTempWidgets=( action == "editdashboardlayout" ) );
+		var dashboard    = widgetService.renderUserGeneratedGridDashboard(
+			  dashboardId     = dashboardId
+			, allowEditing    = allowEditing
+			, contextData     = args.contextData ?: {}
+			, showTempWidgets = ( action == "editdashboardlayout" )
+		);
 
 		event.include( "/js/admin/specific/admindashboards/" )
 		     .include( "/css/admin/specific/admindashboards/" );
@@ -149,7 +154,44 @@ component extends="preside.system.base.AdminHandler" {
 
 		StructAppend( args, dashboard );
 
+		var currentEvent          = rc.event ?: event.getCurrentEvent();
+		var dashboardsForSelector = dashboardService.getDashboardsForSelector(
+			  currentDashboardId = dashboardId
+			, contextData        = args.contextData ?: {}
+			, includeTemplates   = isTrue( args.includeTemplatesForSelector ?: false )
+			, includeUser        = isTrue( args.includeUserForSelector      ?: true )
+			, includeAccess      = isTrue( args.includeAccessForSelector    ?: true )
+		);
+
+		prc.activeDashboard       = dashboardsForSelector.activeDashboard     ?: {};
+		prc.availableDashboards   = dashboardsForSelector.availableDashboards ?: [];
+		prc.showDashboardSelector = !ReFindNoCase( "editDashboardLayout", currentEvent ) && ArrayLen( prc.availableDashboards ) > 0;
+
+		if ( !StructIsEmpty( args.contextData ?: {} ) ) {
+			args.hasContextData    = true;
+			args.nonContextWidgets = ArrayFilter( dashboard.widgets ?: [], function( _widget ) {
+				return isFalse( _widget.supportContext ?: "" );
+			} );
+		}
+
 		return renderView( view="/admin/admindashboards/layoutGrid/_userGenerated", args=args );
+	}
+
+	private string function renderDashboardHeader( event, rc, prc, args={} ) {
+		var includeHeader = isTrue( args.includePageHeader ?: ( prc.includePageHeader ?: false ) );
+		if ( !includeHeader ) {
+			return "";
+		}
+
+		return renderView( view="/admin/admindashboards/layoutGrid/_pageTitle", args={
+			  title                 = ( prc.pageTitle             ?: "" )
+			, subTitle              = ( prc.pageSubTitle          ?: "" )
+			, icon                  = ( prc.pageIcon              ?: "" )
+			, pageHeaderButtons     = ( prc.pageHeaderButtons     ?: "" )
+			, showDashboardSelector = ( prc.showDashboardSelector ?: false )
+			, availableDashboards   = ( prc.availableDashboards   ?: [] )
+			, activeDashboard       = ( prc.activeDashboard       ?: {} )
+		} );
 	}
 
 	public void function importDialog( event, rc, prc ) {
@@ -292,12 +334,13 @@ component extends="preside.system.base.AdminHandler" {
 					continue;
 				}
 
-				widget.title       = translateResource( uri=widget.title      , defaultValue=widget.title );
-				widget.description = translateResource( uri=widget.description, defaultValue="" );
-				widget.icon        = translateResource( uri=widget.icon       , defaultValue="fa-magic" );
-				widget.group       = translateResource( uri="admin.admindashboards.widget.#id#:group", defaultValue="" );
-				widget.isTemplate  = false;
-				widget.isSystem    = true;
+				widget.title          = translateResource( uri=widget.title      , defaultValue=widget.title );
+				widget.description    = translateResource( uri=widget.description, defaultValue="" );
+				widget.icon           = translateResource( uri=widget.icon       , defaultValue="fa-magic" );
+				widget.group          = translateResource( uri="admin.admindashboards.widget.#id#:group", defaultValue="" );
+				widget.isTemplate     = false;
+				widget.isSystem       = true;
+				widget.supportContext = widgetService.isWidgetSupportContext( widget.id );
 
 				ArrayAppend( tempArray, widget );
 
@@ -312,6 +355,6 @@ component extends="preside.system.base.AdminHandler" {
 			return widget1.title == widget2.title ? 0 : ( widget1.title > widget2.title ? 1 : -1 );
 		} );
 
-		return arrayOfStructsToQuery( "id,title,group,description,icon,isTemplate,recordId,config", tempArray );
+		return arrayOfStructsToQuery( "id,title,group,description,icon,isTemplate,recordId,config,supportContext", tempArray );
 	}
 }

--- a/handlers/admin/AdminDashboards.cfc
+++ b/handlers/admin/AdminDashboards.cfc
@@ -140,8 +140,10 @@ component extends="preside.system.base.AdminHandler" {
 		var contextData       = args.contextData ?: {};
 		var layoutAction      = _resolveDashboardLayoutAction( event, rc, args );
 		var includePageHeader = isTrue( args.includePageHeader ?: "" );
+		var adminUserId       = event.getAdminUserId();
 		var viewLink          = dashboardService.buildDashboardViewLink( dashboardId=dashboardId, contextData=contextData );
-		var canEditDashboard  = allowEditing && dashboardService.userCanEditDashboard( dashboardId, event.getAdminUserId() );
+		var canCloneDashboard = dashboardService.hasFullAccess( adminUserId ) || dashboardService.userCanViewDashboard( dashboardId, adminUserId );
+		var canEditDashboard  = allowEditing && dashboardService.userCanEditDashboard( dashboardId, adminUserId );
 		var editLayoutLink    = canEditDashboard ? dashboardService.buildDashboardEditLayoutLink( dashboardId=dashboardId, contextData=contextData ) : "";
 		var deleteReturnUrl   = "";
 
@@ -175,7 +177,7 @@ component extends="preside.system.base.AdminHandler" {
 		args.contextData           = contextData;
 		args.includePageHeader     = includePageHeader;
 
-		var showInlineToolbar = !StructIsEmpty( contextData ) && allowEditing && isTrue( dashboard.canEdit ?: "" );
+		var showInlineToolbar = !StructIsEmpty( contextData ) && allowEditing;
 
 		if ( showInlineToolbar ) {
 			args.showInlineDashboardEditToolbar   = true;
@@ -185,6 +187,16 @@ component extends="preside.system.base.AdminHandler" {
 			args.inlineToolbarCancelLink          = event.buildAdminLink( linkTo="AdminDashboards.cancelEditDashboardLayout", queryString="dashboardId=#dashboardId#&returnUrl=#UrlEncodedFormat( viewLink )#" );
 			args.inlineToolbarHasTempWidgets      = widgetService.hasTempDashboardWidgets( dashboardId=dashboardId );
 			args.inlineToolbarPostAddDashboardUrl = layoutAction == "editdashboardlayout" ? editLayoutLink : "";
+
+			args.inlineToolbarCanShareDashboard   = dashboardService.userCanShareDashboard( dashboardId, adminUserId );
+			args.inlineToolbarCanEditDashboard    = canEditDashboard;
+			args.inlineToolbarCanCloneDashboard   = canCloneDashboard;
+			args.inlineToolbarCanDeleteDashboard  = dashboardService.userCanDeleteDashboard( dashboardId, adminUserId );
+
+			args.inlineToolbarShareLink           = args.inlineToolbarCanShareDashboard  ? dashboardService.buildDashboardShareLink( dashboardId=dashboardId, contextData=contextData )      : "";
+			args.inlineToolbarEditRecordLink      = args.inlineToolbarCanEditDashboard   ? dashboardService.buildDashboardEditRecordLink( dashboardId=dashboardId, contextData=contextData ) : "";
+			args.inlineToolbarCloneLink           = args.inlineToolbarCanCloneDashboard  ? dashboardService.buildDashboardCloneLink( dashboardId=dashboardId, contextData=contextData )      : "";
+			args.inlineToolbarDeleteLink          = args.inlineToolbarCanDeleteDashboard ? dashboardService.buildDashboardDeleteLink( dashboardId=dashboardId, contextData=contextData )     : "";
 		} else {
 			args.showInlineDashboardEditToolbar   = false;
 			args.inlineToolbarPostAddDashboardUrl = "";

--- a/handlers/admin/AdminDashboards.cfc
+++ b/handlers/admin/AdminDashboards.cfc
@@ -295,13 +295,14 @@ component extends="preside.system.base.AdminHandler" {
 
 	public function deleteWidget( event, rc, prc, args={} ) {
 		var dashboardId = args.dashboardId ?: ( rc.dashboardId ?: "" );
-		var instanceId  = args.instanceId  ?: ( rc.instanceId  ?: "" );
-		var defaultUrl  = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
-		var nextUrl     = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
 
 		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
 			event.adminAccessDenied();
 		}
+
+		var instanceId = args.instanceId  ?: ( rc.instanceId  ?: "" );
+		var defaultUrl = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
+		var nextUrl    = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
 
 		widgetService.deleteWidget(
 			  dashboardId = dashboardId
@@ -313,12 +314,13 @@ component extends="preside.system.base.AdminHandler" {
 
 	public function saveEditDashboardLayout( event, rc, prc, args={} ) {
 		var dashboardId = args.dashboardId ?: ( rc.dashboardId ?: "" );
-		var defaultUrl  = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
-		var nextUrl     = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
 
 		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
 			event.adminAccessDenied();
 		}
+
+		var defaultUrl = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
+		var nextUrl    = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
 
 		widgetService.saveEditDashboardWidgets( dashboardId=dashboardId );
 
@@ -327,12 +329,13 @@ component extends="preside.system.base.AdminHandler" {
 
 	public function cancelEditDashboardLayout( event, rc, prc, args={} ) {
 		var dashboardId = args.dashboardId ?: ( rc.dashboardId ?: "" );
-		var defaultUrl  = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
-		var nextUrl     = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
 
 		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
 			event.adminAccessDenied();
 		}
+
+		var defaultUrl = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
+		var nextUrl    = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
 
 		widgetService.cancelEditDashboardWidgets( dashboardId=dashboardId );
 
@@ -341,13 +344,14 @@ component extends="preside.system.base.AdminHandler" {
 
 	public string function updateWidgetOrder( event, rc, prc, args={} ) {
 		var dashboardId = rc.dashboardId ?: "";
-		var column      = rc.column      ?: 1;
-		var widgets     = rc.widgets     ?: [];
-		var dao         = getPresideObject( "admin_dashboard_widget" );
 
 		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
 			event.adminAccessDenied();
 		}
+
+		var column  = rc.column      ?: 1;
+		var widgets = rc.widgets     ?: [];
+		var dao     = getPresideObject( "admin_dashboard_widget" );
 
 		widgets.each( function( widget, slot ) {
 			dao.updateData(

--- a/handlers/admin/AdminDashboards.cfc
+++ b/handlers/admin/AdminDashboards.cfc
@@ -135,39 +135,74 @@ component extends="preside.system.base.AdminHandler" {
 	}
 
 	private string function renderUserGeneratedDashboard( event, rc, prc, args={} ) {
-		var dashboardId  = args.dashboardId ?: "";
-		var allowEditing = isTrue( args.allowEditing ?: "" );
-		var action       = ListLast( rc.event ?: "", "." );
-		var dashboard    = widgetService.renderUserGeneratedGridDashboard(
-			  dashboardId     = dashboardId
-			, allowEditing    = allowEditing
-			, contextData     = args.contextData ?: {}
-			, showTempWidgets = ( action == "editdashboardlayout" )
+		var dashboardId       = args.dashboardId ?: "";
+		var allowEditing      = isTrue( args.allowEditing ?: "" );
+		var contextData       = args.contextData ?: {};
+		var layoutAction      = _resolveDashboardLayoutAction( event, rc, args );
+		var includePageHeader = isTrue( args.includePageHeader ?: "" );
+		var viewLink          = dashboardService.buildDashboardViewLink( dashboardId=dashboardId, contextData=contextData );
+		var canEditDashboard  = allowEditing && dashboardService.userCanEditDashboard( dashboardId, event.getAdminUserId() );
+		var editLayoutLink    = canEditDashboard ? dashboardService.buildDashboardEditLayoutLink( dashboardId=dashboardId, contextData=contextData ) : "";
+		var deleteReturnUrl   = "";
+
+		if ( layoutAction == "editdashboardlayout" ) {
+			if ( Len( Trim( contextData.context ?: "" ) ) ) {
+				deleteReturnUrl = Len( editLayoutLink ) ? editLayoutLink : viewLink;
+			} else {
+				deleteReturnUrl = event.buildAdminLink( objectName="admin_dashboard", operation="editdashboardlayout", recordId=dashboardId );
+			}
+		}
+
+		var dashboard = widgetService.renderUserGeneratedGridDashboard(
+			  dashboardId           = dashboardId
+			, allowEditing          = allowEditing
+			, contextData           = contextData
+			, showTempWidgets       = ( layoutAction == "editdashboardlayout" )
+			, deleteWidgetReturnUrl = deleteReturnUrl
+			, dashboardLayoutAction = layoutAction
 		);
 
 		event.include( "/js/admin/specific/admindashboards/" )
 		     .include( "/css/admin/specific/admindashboards/" );
 
-		if ( isTrue( dashboard.canEdit ?: "" ) ) {
+		if ( isTrue( dashboard.canEdit ?: "" ) && layoutAction == "editdashboardlayout" ) {
 			event.include( "/js/admin/specific/admindashboards/editing/" );
 		}
 
 		StructAppend( args, dashboard );
 
-		var currentEvent          = rc.event ?: event.getCurrentEvent();
+		args.dashboardLayoutAction = layoutAction;
+		args.contextData           = contextData;
+		args.includePageHeader     = includePageHeader;
+
+		var showInlineToolbar = !StructIsEmpty( contextData ) && allowEditing && isTrue( dashboard.canEdit ?: "" );
+
+		if ( showInlineToolbar ) {
+			args.showInlineDashboardEditToolbar   = true;
+			args.inlineToolbarViewLink            = viewLink;
+			args.inlineToolbarEditLink            = editLayoutLink;
+			args.inlineToolbarSaveLink            = event.buildAdminLink( linkTo="AdminDashboards.saveEditDashboardLayout", queryString="dashboardId=#dashboardId#&returnUrl=#UrlEncodedFormat( viewLink )#" );
+			args.inlineToolbarCancelLink          = event.buildAdminLink( linkTo="AdminDashboards.cancelEditDashboardLayout", queryString="dashboardId=#dashboardId#&returnUrl=#UrlEncodedFormat( viewLink )#" );
+			args.inlineToolbarHasTempWidgets      = widgetService.hasTempDashboardWidgets( dashboardId=dashboardId );
+			args.inlineToolbarPostAddDashboardUrl = layoutAction == "editdashboardlayout" ? editLayoutLink : "";
+		} else {
+			args.showInlineDashboardEditToolbar   = false;
+			args.inlineToolbarPostAddDashboardUrl = "";
+		}
+
 		var dashboardsForSelector = dashboardService.getDashboardsForSelector(
 			  currentDashboardId = dashboardId
-			, contextData        = args.contextData ?: {}
+			, contextData        = contextData
 			, includeTemplates   = isTrue( args.includeTemplatesForSelector ?: false )
 			, includeUser        = isTrue( args.includeUserForSelector      ?: true )
 			, includeAccess      = isTrue( args.includeAccessForSelector    ?: true )
 		);
 
-		prc.activeDashboard       = dashboardsForSelector.activeDashboard     ?: {};
-		prc.availableDashboards   = dashboardsForSelector.availableDashboards ?: [];
-		prc.showDashboardSelector = !ReFindNoCase( "editDashboardLayout", currentEvent ) && ArrayLen( prc.availableDashboards ) > 0;
+		prc.activeDashboard        = dashboardsForSelector.activeDashboard     ?: {};
+		prc.availableDashboards    = dashboardsForSelector.availableDashboards ?: [];
+		prc.showDashboardSelector  = ( layoutAction != "editdashboardlayout" ) && ArrayLen( prc.availableDashboards ) > 0;
 
-		if ( !StructIsEmpty( args.contextData ?: {} ) ) {
+		if ( !StructIsEmpty( contextData ) ) {
 			args.hasContextData    = true;
 			args.nonContextWidgets = ArrayFilter( dashboard.widgets ?: [], function( _widget ) {
 				return isFalse( _widget.supportContext ?: "" );
@@ -187,7 +222,7 @@ component extends="preside.system.base.AdminHandler" {
 			  title                 = ( prc.pageTitle             ?: "" )
 			, subTitle              = ( prc.pageSubTitle          ?: "" )
 			, icon                  = ( prc.pageIcon              ?: "" )
-			, pageHeaderButtons     = ( prc.pageHeaderButtons     ?: "" )
+			, pageHeaderButtons     = ( prc.pageHeaderButtons     ?: ( args.pageHeaderButtons ?: "" ) )
 			, showDashboardSelector = ( prc.showDashboardSelector ?: false )
 			, availableDashboards   = ( prc.availableDashboards   ?: [] )
 			, activeDashboard       = ( prc.activeDashboard       ?: {} )
@@ -234,6 +269,12 @@ component extends="preside.system.base.AdminHandler" {
 		var nextSlot    = widgetService.nextWidgetSlot( dashboardId, column );
 		var title       = widgetService.getInstanceTitle( dashboardId, widgetId );
 		var config      = {};
+		var defaultUrl  = event.buildAdminLink( objectName="admin_dashboard", operation="editdashboardlayout", recordId=dashboardId );
+		var nextUrl     = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
+
+		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
+			event.adminAccessDenied();
+		}
 
 		if ( Len( templateId ) ) {
 			config = widgetService.getSystemWidgetTemplateConfig( templateId=templateId );
@@ -249,35 +290,53 @@ component extends="preside.system.base.AdminHandler" {
 			, config      = config
 		);
 
-		setNextEvent( url=event.buildAdminLink( objectName="admin_dashboard", operation="editdashboardlayout", recordId=dashboardId ) );
+		setNextEvent( url=nextUrl );
 	}
 
 	public function deleteWidget( event, rc, prc, args={} ) {
 		var dashboardId = args.dashboardId ?: ( rc.dashboardId ?: "" );
 		var instanceId  = args.instanceId  ?: ( rc.instanceId  ?: "" );
+		var defaultUrl  = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
+		var nextUrl     = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
+
+		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
+			event.adminAccessDenied();
+		}
 
 		widgetService.deleteWidget(
 			  dashboardId = dashboardId
 			, instanceId  = instanceId
 		);
 
-		setNextEvent( url=event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId ) );
+		setNextEvent( url=nextUrl );
 	}
 
 	public function saveEditDashboardLayout( event, rc, prc, args={} ) {
 		var dashboardId = args.dashboardId ?: ( rc.dashboardId ?: "" );
+		var defaultUrl  = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
+		var nextUrl     = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
+
+		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
+			event.adminAccessDenied();
+		}
 
 		widgetService.saveEditDashboardWidgets( dashboardId=dashboardId );
 
-		setNextEvent( url=event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId ) );
+		setNextEvent( url=nextUrl );
 	}
 
 	public function cancelEditDashboardLayout( event, rc, prc, args={} ) {
 		var dashboardId = args.dashboardId ?: ( rc.dashboardId ?: "" );
+		var defaultUrl  = event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId );
+		var nextUrl     = dashboardService.getValidatedAdminReturnUrlOrDefault( candidateUrl=rc.returnUrl ?: "", defaultUrl=defaultUrl );
+
+		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
+			event.adminAccessDenied();
+		}
 
 		widgetService.cancelEditDashboardWidgets( dashboardId=dashboardId );
 
-		setNextEvent( url=event.buildAdminLink( objectName="admin_dashboard", recordId=dashboardId ) );
+		setNextEvent( url=nextUrl );
 	}
 
 	public string function updateWidgetOrder( event, rc, prc, args={} ) {
@@ -285,6 +344,10 @@ component extends="preside.system.base.AdminHandler" {
 		var column      = rc.column      ?: 1;
 		var widgets     = rc.widgets     ?: [];
 		var dao         = getPresideObject( "admin_dashboard_widget" );
+
+		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
+			event.adminAccessDenied();
+		}
 
 		widgets.each( function( widget, slot ) {
 			dao.updateData(
@@ -303,6 +366,10 @@ component extends="preside.system.base.AdminHandler" {
 		var dao         = getPresideObject( "admin_dashboard_widget" );
 		var dataField   = isTrue( isTemporary ) ? "dashboard_edit_temp_grid_config" : "grid_config";
 
+		if ( !_userCanMutateDashboard( event, dashboardId ) ) {
+			event.adminAccessDenied();
+		}
+
 		widgets = deserializeJSON( widgets );
 
 		widgets.each( function( widget, i ) {
@@ -317,6 +384,47 @@ component extends="preside.system.base.AdminHandler" {
 
 
 // private helpers
+
+	private string function _resolveDashboardLayoutAction( event, rc, prc, args={} ) {
+		var fromArgs    = Trim( args.dashboardLayoutAction ?: "" );
+		var dashboardId = args.dashboardId ?: ( rc.currentDashboard ?: "" );
+
+		if ( Len( fromArgs ) ) {
+			return LCase( fromArgs );
+		}
+
+		var evt = LCase( ListLast( rc.event ?: "", "." ) );
+
+		if ( evt == "editdashboardlayout" || evt == "viewrecord" ) {
+			return evt;
+		}
+
+		if ( isTrue( rc.adminDashboardEditLayout ?: "" ) &&
+			 hasCmsPermission( "adminDashboards.edit" ) &&
+			 Len( dashboardId ) &&
+			 dashboardService.userCanEditDashboard( dashboardId, event.getAdminUserId() )
+		) {
+			return "editdashboardlayout";
+		}
+
+		return "viewrecord";
+	}
+
+	private boolean function _userCanMutateDashboard( event, required string dashboardId ) {
+		if ( !Len( Trim( arguments.dashboardId ) ) ) {
+			return false;
+		}
+
+		if ( !hasCmsPermission( "adminDashboards.edit" ) ) {
+			return false;
+		}
+
+		if ( dashboardService.isSystemDashboard( arguments.dashboardId ) ) {
+			return false;
+		}
+
+		return dashboardService.userCanEditDashboard( arguments.dashboardId, event.getAdminUserId() );
+	}
 
 	private query function _getSortedAndTranslatedAdminWidgets() {
 		// todo, cache this operation (per locale)

--- a/handlers/admin/AdminDashboards.cfc
+++ b/handlers/admin/AdminDashboards.cfc
@@ -411,7 +411,7 @@ component extends="preside.system.base.AdminHandler" {
 
 		var evt = LCase( ListLast( rc.event ?: "", "." ) );
 
-		if ( evt == "editdashboardlayout" || evt == "viewrecord" ) {
+		if ( evt == "editdashboardlayout" ) {
 			return evt;
 		}
 
@@ -421,6 +421,10 @@ component extends="preside.system.base.AdminHandler" {
 			 dashboardService.userCanEditDashboard( dashboardId, event.getAdminUserId() )
 		) {
 			return "editdashboardlayout";
+		}
+
+		if ( evt == "viewrecord" ) {
+			return evt;
 		}
 
 		return "viewrecord";

--- a/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
+++ b/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
@@ -45,7 +45,8 @@ component extends="preside.system.base.AdminHandler" {
 			}
 		}
 
-		return renderView( view="/admin/datamanager/_objectDataTable", args={
+		args.autoCtaLinkUrl = _buildAutoCtaLink( event=event, args=args );
+		args.tableHtml      = renderView( view="/admin/datamanager/_objectDataTable", args={
 			  objectName        = objectName
 			, useMultiActions   = false
 			, allowSearch       = false
@@ -55,6 +56,8 @@ component extends="preside.system.base.AdminHandler" {
 			, sortableFields    = listToArray( sortableFields )
 			, filterContextData = { widgetInstanceId=args.instanceId ?: "" }
 		} );
+
+		return renderView( view="/admin/admindashboards/widget/dashboardDataFilter/render", args=args );
 	}
 
 	private boolean function isUserDashboardWidget( event, rc, prc, args={} ) {
@@ -124,6 +127,58 @@ component extends="preside.system.base.AdminHandler" {
 				, extraFilters = extraFilters
 			}
 		);
+	}
+
+// PRIVATE HELPERs
+	private string function _buildAutoCtaLink( event, args={} ) {
+		var objectName  = Trim( args.config.applies_to ?: "" );
+		var savedFilter = Trim( args.config.filter     ?: "" );
+
+		if ( !Len( objectName ) ) {
+			return "";
+		}
+
+		if ( isWidgetSupportContext( argumentCollection=arguments ) ) {
+			var ctaViewlet = "admin.admindashboards.context.#objectName#.dashboardDataFilter.buildCtaLink";
+			var coldbox    = getController();
+
+			if ( coldbox.viewletExists( ctaViewlet ) ) {
+				var ctaResult = coldbox.renderViewlet(
+					  event          = ctaViewlet
+					, args           = args
+					, throwOnMissing = false
+				);
+
+				if ( Len( Trim( ctaResult ?: "" ) ) ) {
+					return ctaResult;
+				}
+			}
+		}
+
+		if ( !( dataManagerService.isObjectAvailableInDataManager( objectName=objectName ) ) ||
+		     !( dataManagerService.isOperationAllowed( objectName=objectName, operation="read" ) ) ||
+		     !( hasCmsPermission( permissionKey="datamanager.navigate", context="datamanager", contextKeys=[ objectName ] ) )
+		) {
+			return "";
+		}
+
+		if ( Len( savedFilter ) ) {
+			var filterExpressions = getPresideObject( "rules_engine_condition" ).selectData(
+				  id           = savedFilter
+				, selectFields = [ "expressions" ]
+				, returntype   = "singleValue"
+				, columnKey    = "expressions"
+			);
+
+			if ( Len( filterExpressions ) ) {
+				return event.buildAdminLink(
+					  objectName  = objectName
+					, queryString = "filter=#UrlEncode( ToBase64( filterExpressions ) )#"
+				);
+			}
+		}
+
+		return event.buildAdminLink( objectName=objectName );
 	}
 
 	public void function getObjectGridFieldsForAjaxControl( event, rc, prc ) {

--- a/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
+++ b/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
@@ -26,12 +26,31 @@ component extends="preside.system.base.AdminHandler" {
 			return !isEmptyString( item );
 		});
 
+		var datasourceQueryString = "action=admindashboards.widget.DashboardDataFilter.getFilterResultsForAjaxDatatables&objectName=#objectName#&gridFields=#arrayToList( gridFields )#&sSavedFilterExpressions=#savedFilter#";
+
+		if ( isWidgetSupportContext( argumentCollection=arguments ) ) {
+			var prepareViewlet = "admin.admindashboards.context.#objectName#.dashboardDataFilter.prepareContextFilter";
+			var coldbox        = getController();
+
+			if ( coldbox.viewletExists( prepareViewlet ) ) {
+				var preparedFilters = coldbox.renderViewlet(
+					  event          = prepareViewlet
+					, args           = args
+					, throwOnMissing = false
+				);
+
+				if ( IsArray( preparedFilters ) && ArrayLen( preparedFilters ) ) {
+					datasourceQueryString &= "&sContextExtraFilters=#URLEncodedFormat( SerializeJson( preparedFilters ) )#";
+				}
+			}
+		}
+
 		return renderView( view="/admin/datamanager/_objectDataTable", args={
 			  objectName        = objectName
 			, useMultiActions   = false
 			, allowSearch       = false
 			, allowFilter       = false
-			, datasourceUrl     = event.buildAdminLink( linkTo="ajaxProxy", queryString="action=admindashboards.widget.DashboardDataFilter.getFilterResultsForAjaxDatatables&objectName=#objectName#&gridFields=#arrayToList( gridFields )#&sSavedFilterExpressions=#savedFilter#" )
+			, datasourceUrl     = event.buildAdminLink( linkTo="ajaxProxy", queryString=datasourceQueryString )
 			, gridFields        = gridFields
 			, sortableFields    = listToArray( sortableFields )
 			, filterContextData = { widgetInstanceId=args.instanceId ?: "" }
@@ -40,6 +59,29 @@ component extends="preside.system.base.AdminHandler" {
 
 	private boolean function isUserDashboardWidget( event, rc, prc, args={} ) {
 		return true;
+	}
+
+	private boolean function isWidgetSupportContext( event, rc, prc, args={} ) {
+		var targetObject = Trim( args.config.applies_to ?: args.contextData.applies_to ?: "" );
+
+		if ( isEmptyString( targetObject ) ) {
+			return false;
+		}
+
+		var supportViewlet = "admin.admindashboards.context.#targetObject#.dashboardDataFilter.supportContext";
+		var coldbox        = getController();
+
+		if ( !coldbox.viewletExists( supportViewlet ) ) {
+			return false;
+		}
+
+		var viewletResult = coldbox.renderViewlet(
+			  event          = supportViewlet
+			, args           = args
+			, throwOnMissing = false
+		);
+
+		return isTrue( viewletResult ?: "" );
 	}
 
 	private string function ajaxCallback( event, rc, prc, args={} ) {
@@ -58,15 +100,28 @@ component extends="preside.system.base.AdminHandler" {
 			return "";
 		}
 
+		var extraFilters = [];
+
+		if ( Len( Trim( rc.sContextExtraFilters ?: "" ) ) ) {
+			try {
+				var decoded = DeserializeJSON( rc.sContextExtraFilters );
+
+				if ( IsArray( decoded ) ) {
+					extraFilters = decoded;
+				}
+			} catch ( any e ) {}
+		}
+
 		runEvent(
 			  event          = "admin.DataManager._getObjectRecordsForAjaxDataTables"
 			, prePostExempt  = true
 			, private        = true
 			, includeActions = false
 			, eventArguments = {
-				  object      = rc.objectName
-				, actionsView = "/admin/admindashboards/widget/dashboardDataFilter/_gridActions"
-				, gridFields  = rc.gridFields
+				  object       = rc.objectName
+				, actionsView  = "/admin/admindashboards/widget/dashboardDataFilter/_gridActions"
+				, gridFields   = rc.gridFields
+				, extraFilters = extraFilters
 			}
 		);
 	}

--- a/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
+++ b/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
@@ -156,7 +156,7 @@ component extends="preside.system.base.AdminHandler" {
 			}
 		}
 
-		if ( !( dataManagerService.isObjectAvailableInDataManager( objectName=objectName ) ) ||
+		if ( !( dataManagerService.objectIsIndexedInDatamanagerUi( objectName=objectName ) ) ||
 		     !( dataManagerService.isOperationAllowed( objectName=objectName, operation="read" ) ) ||
 		     !( hasCmsPermission( permissionKey="datamanager.navigate", context="datamanager", contextKeys=[ objectName ] ) )
 		) {

--- a/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
+++ b/handlers/admin/admindashboards/widget/DashboardDataFilter.cfc
@@ -93,6 +93,7 @@ component extends="preside.system.base.AdminHandler" {
 	private void function ajaxIncludes( event, rc, prc, args={} ) {
 		event.include( "/js/admin/specific/datamanager/object/");
 		event.include( "/css/admin/specific/datamanager/object/");
+		event.include( "/css/admin/specific/admindashboards/dataviz/", false );
 		event.includeData( data={ defaultPageLength=5 } );
 
 		event.includeInlineJs( "( function( $ ){ widget_#replace( args.configInstanceId, "-", "", "all" )#_init = function() { $( 'div[data-config-instance-id=#args.configInstanceId#].admin-dashboard-widget .object-listing-table' ).dataListingTable(); }; } )( presideJQuery );" );

--- a/handlers/admin/datamanager/admin_dashboard.cfc
+++ b/handlers/admin/datamanager/admin_dashboard.cfc
@@ -4,6 +4,7 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 	property name="widgetService"        inject="adminDashboardWidgetService";
 	property name="datamanagerService"   inject="datamanagerService";
 	property name="presideObjectService" inject="presideObjectService";
+	property name="enumService"          inject="enumService";
 
 	variables.sidebarNavigation = true;
 	variables.infoCol3          = [];
@@ -47,12 +48,32 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 	public void function preRenderListing( event, rc, prc, args={} ) {
 		prc.adminSidebarItems = prc.adminSidebarItems ?: [];
 
+		var curEvent  = event.getCurrentEvent();
+		var curObject = prc.objectName ?: "";
+		var forSystem = isTrue( rc.systemOnly ?: "" );
+
+		if ( forSystem ) {
+			prc.gridFields       = [ "contexts", "name", "description", "datecreated" ];
+			prc.hiddenGridFields = prc.hiddenGridFields ?: [];
+			ArrayAppend( prc.hiddenGridFields, [ "view_access", "edit_access" ], true );
+		}
+
 		ArrayAppend( prc.adminSidebarItems, {
-			  active = event.getCurrentEvent() == "admin.datamanager.object"
+			  active = !forSystem && ( curEvent == "admin.datamanager.object" ) && ( curObject == "admin_dashboard" )
 			, title  = translateResource( uri="preside-objects.admin_dashboard:sidenav.all.label" )
 			, link   = event.buildAdminLink( objectName="admin_dashboard" )
 			, icon   = "fa-tachometer"
 		} );
+
+		prc.hasSystemDashboards = prc.hasSystemDashboards ?: getPresideObject( "admin_dashboard" ).dataExists( filter={ is_system=true, owner="" } );
+		if ( isTrue( prc.hasSystemDashboards ) ) {
+			ArrayAppend( prc.adminSidebarItems, {
+				  active = forSystem && ( curEvent == "admin.datamanager.object" ) && ( curObject == "admin_dashboard" )
+				, title  = translateResource( uri="preside-objects.admin_dashboard:sidenav.systemdashboards.title" )
+				, link   = event.buildAdminLink( objectName="admin_dashboard", queryString="systemOnly=true" )
+				, icon   = "fa-th-large"
+			} );
+		}
 
 		var createdByMeDashboards = _getCreatedByMeSidenav( argumentCollection=arguments );
 		if ( !StructIsEmpty( createdByMeDashboards ) ) {
@@ -69,14 +90,51 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 		prc.pageIcon           = "";
 	}
 
+	private string function listingViewlet( event, rc, prc, args={} ) {
+		var forSystem = isTrue( rc.systemOnly ?: "" );
+
+		if ( forSystem ) {
+			args.allRecordsLink       = event.buildAdminLink( objectName="admin_dashboard", queryString="systemOnly=true" );
+			args.categoryLinkBase     = event.buildAdminLink( objectName="admin_dashboard", queryString="systemOnly=true&activeCategoryId={activeCategoryId}" );
+			args.allListingCategories = enumService.listItems( enum="adminDashboardContexts" );
+			args.currentListingView   = runEvent(
+				  event          = "admin.dataManager._objectListingViewlet"
+				, private        = true
+				, prePostExempt  = true
+				, eventArguments = { args=args }
+			);
+
+			return renderView( view="/admin/datamanager/_listingWithCategories", args=args );
+		}
+
+		return super.listingViewlet( argumentCollection=arguments );
+	}
+
+	private string function getAdditionalQueryStringForBuildAjaxListingLink( event, rc, prc, args={} ) {
+		var qs = [];
+
+		if ( isTrue( rc.systemOnly ?: "" ) ) {
+			ArrayAppend( qs, "systemOnly=true" );
+		}
+
+		if ( Len( rc.activeCategoryId ?: "" ) ) {
+			ArrayAppend( qs, "context=#UrlEncodedFormat( rc.activeCategoryId )#" );
+		}
+
+		return ArrayToList( qs, "&" );
+	}
+
 	private void function preFetchRecordsForGridListing( event, rc, prc, args={} ) {
+		args.extraFilters = args.extraFilters ?: [];
+
+		var systemOnly  = isTrue( rc.systemOnly ?: "" );
+		var contextVal  = Trim( rc.context ?: "" );
 		var adminUserId = event.getAdminUserId();
 
 		if ( !dashboardService.hasFullAccess( adminUserId ) ) {
 			var adminUserGroups = _getAdminUserGroups( adminUserId );
 
 			args.selectFields = args.selectFields ?: [];
-			args.extraFilters = args.extraFilters ?: [];
 			args.extraFilters.append( {
 				  filter       = "view_access = 'public'
 						or admin_dashboard.owner = :adminUserId
@@ -94,6 +152,19 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 			ArrayAppend( args.selectFields, "edit_groups_list" );
 			ArrayAppend( args.selectFields, "edit_users_list"  );
 		}
+
+		if ( systemOnly ) {
+			ArrayAppend( args.extraFilters, { filter={ is_system=true } } );
+		} else {
+			ArrayAppend( args.extraFilters, { filter={ is_system=false } } );
+		}
+
+		if ( Len( contextVal ) ) {
+			ArrayAppend( args.extraFilters, {
+				  filter       = "admin_dashboard.contexts LIKE (:contexts)"
+				, filterParams = { contexts={ type="cf_sql_varchar", value="%#contextVal#%" } }
+			} );
+		}
 	}
 
 	private void function postFetchRecordsForGridListing( event, rc, prc, args={} ) {
@@ -108,16 +179,27 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 		var canClone        = [];
 		var canViewThis     = false;
 		var canEditThis     = false;
+		var isSystem        = false;
 		var hasFullAccess   = dashboardService.hasFullAccess( adminUserId );
 
 		for ( var r in records ) {
 			canEditThis = ( prc.canEdit ?: false ) && ( r.owner_id == adminUserId || ( r.edit_access == "specific" && ( listFind( r.edit_users_list, adminUserId ) || _listFindOneOf( r.edit_groups_list, adminUserGroups ) ) ) );
-			canViewThis = canEditThis || r.view_access == "public" || ( r.view_access == "specific" && ( listFind( r.view_users_list, adminUserId ) || _listFindOneOf( r.view_groups_list, adminUserGroups ) ) )
-			ArrayAppend( canEdit  , hasFullAccess || canEditThis );
+			canViewThis = canEditThis || r.view_access == "public" || ( r.view_access == "specific" && ( listFind( r.view_users_list, adminUserId ) || _listFindOneOf( r.view_groups_list, adminUserGroups ) ) );
+			isSystem    = isTrue( r.is_system ?: dashboardService.isSystemDashboard( dashboardId=r.id ) );
+
+			ArrayAppend( canEdit  , !isSystem && ( hasFullAccess || canEditThis ) );
 			ArrayAppend( canView  , hasFullAccess || canViewThis );
-			ArrayAppend( canShare , hasFullAccess || r.owner_id == adminUserId );
-			ArrayAppend( canDelete, hasFullAccess || ( ( prc.canDelete ?: false ) && r.owner_id == adminUserId ) );
+			ArrayAppend( canShare , !isSystem && ( hasFullAccess || r.owner_id == adminUserId ) );
+			ArrayAppend( canDelete, !isSystem && ( hasFullAccess || ( ( prc.canDelete ?: false ) && r.owner_id == adminUserId ) ) );
 			ArrayAppend( canClone , hasFullAccess || ( ( prc.canClone  ?: false ) && canViewThis ) );
+
+			if ( StructKeyExists( r, "contexts" ) ) {
+				QuerySetCell( records, "contexts", renderContent(
+					  renderer = "adminDashboardContexts"
+					, data     = r.contexts
+					, args     = r
+				), QueryCurrentRow( records ) );
+			}
 		}
 
 		QueryAddColumn( records, "canView"  , canView   );
@@ -215,12 +297,25 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 	}
 
 	private string function renderSidebarHeader( event, rc, prc, args={} ) {
+		var curEvent           = event.getCurrentEvent();
+		var curObject          = prc.objectName ?: "";
+		var forSystem          = isTrue( rc.systemOnly ?: "" );
 		var customSidebarItems = [ {
-			  active = event.getCurrentEvent() == "admin.datamanager.object"
+			  active = !forSystem && ( curEvent == "admin.datamanager.object" ) && ( curObject == "admin_dashboard" )
 			, title  = translateResource( uri="preside-objects.admin_dashboard:sidenav.all.label" )
 			, link   = event.buildAdminLink( objectName="admin_dashboard" )
 			, icon   = "fa-tachometer"
 		} ];
+
+		prc.hasSystemDashboards = prc.hasSystemDashboards ?: getPresideObject( "admin_dashboard" ).dataExists( filter={ is_system=true, owner="" } );
+		if ( isTrue( prc.hasSystemDashboards ) ) {
+			ArrayAppend( customSidebarItems, {
+				  active = forSystem && ( curEvent == "admin.datamanager.object" ) && ( curObject == "admin_dashboard" )
+				, title  = translateResource( uri="preside-objects.admin_dashboard:sidenav.systemdashboards.title" )
+				, link   = event.buildAdminLink( objectName="admin_dashboard", queryString="systemOnly=true" )
+				, icon   = "fa-th-large"
+			} );
+		}
 
 		var createdByMeDashboards = _getCreatedByMeSidenav( argumentCollection=arguments );
 		if ( !StructIsEmpty( createdByMeDashboards ) ) {
@@ -480,7 +575,7 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 		var objectName = "admin_dashboard"
 		var recordId   = rc.id ?: "";
 
-		if ( !dashboardService.userCanEditDashboard( recordId, event.getAdminUserId() ) ) {
+		if ( dashboardService.isSystemDashboard( recordId ) || !dashboardService.userCanEditDashboard( recordId, event.getAdminUserId() ) ) {
 			event.adminAccessDenied();
 		}
 

--- a/handlers/admin/datamanager/admin_dashboard.cfc
+++ b/handlers/admin/datamanager/admin_dashboard.cfc
@@ -507,7 +507,21 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 	}
 
 	public void function sharingAction( event, rc, prc, args={} ) {
-		var recordId = rc.id ?: "";
+		var recordId           = rc.id                 ?: "";
+		var redirectObjectName = rc.redirectObjectName ?: "";
+		var redirectRecordId   = rc.redirectRecordId   ?: "";
+		var successUrl         = event.buildAdminLink( objectName="admin_dashboard", recordId=recordId );
+		var errorUrl           = event.buildAdminLink( objectName="admin_dashboard", recordId=recordId, operation="sharing" );
+
+		if ( Len( redirectObjectName ) ) {
+			successUrl = event.buildAdminLink( objectName=redirectObjectName, recordId=redirectRecordId );
+			errorUrl   = event.buildAdminLink(
+				  objectName  = "admin_dashboard"
+				, operation   = "sharing"
+				, recordId    = recordId
+				, queryString = "redirectObjectName=#redirectObjectName#&redirectRecordId=#redirectRecordId#"
+			);
+		}
 
 		if ( !dashboardService.userCanShareDashboard( recordId, event.getAdminUserId() ) ) {
 			event.adminAccessDenied();
@@ -529,8 +543,8 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 			, eventArguments = {
 				  object      = "admin_dashboard"
 				, formName    = "preside-objects.admin_dashboard.sharing"
-				, errorUrl    = event.buildAdminLink( objectName="admin_dashboard", recordId=recordId, operation="sharing" )
-				, successUrl  = event.buildAdminLink( objectName="admin_dashboard", recordId=recordId )
+				, errorUrl    = errorUrl
+				, successUrl  = successUrl
 				, audit       = true
 				, auditAction = "edit_sharing_options"
 			  }
@@ -585,6 +599,54 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 		}
 
 		return event.buildAdminLink( linkto="datamanager.admin_dashboard.editdashboardlayout", querystring=qs );
+	}
+
+	private any function editRecordAction( event, rc, prc, args={} ) {
+		var redirectObjectName = rc.redirectObjectName ?: "";
+		var redirectRecordId   = rc.redirectRecordId   ?: "";
+
+		if ( Len( redirectObjectName ) ) {
+			args.successUrl = event.buildAdminLink( objectName=redirectObjectName, recordId=redirectRecordId );
+		}
+
+		runEvent(
+			  event          = "admin.DataManager._editRecordAction"
+			, prePostExempt  = true
+			, private        = true
+			, eventArguments = args
+		);
+	}
+
+	private any function cloneRecordAction( event, rc, prc, args={} ) {
+		var redirectObjectName = rc.redirectObjectName ?: "";
+		var redirectRecordId   = rc.redirectRecordId   ?: "";
+
+		if ( Len( redirectObjectName ) ) {
+			args.successUrl = event.buildAdminLink( objectName=redirectObjectName, recordId=redirectRecordId ) & "&currentDashboard={id}";
+		}
+
+		runEvent(
+			  event          = "admin.DataManager._cloneRecordAction"
+			, prePostExempt  = true
+			, private        = true
+			, eventArguments = args
+		);
+	}
+
+	private any function deleteRecordAction( event, rc, prc, args={} ) {
+		var redirectObjectName = rc.redirectObjectName ?: "";
+		var redirectRecordId   = rc.redirectRecordId   ?: "";
+
+		if ( Len( redirectObjectName ) ) {
+			args.postActionUrl = event.buildAdminLink( objectName=redirectObjectName, recordId=redirectRecordId );
+		}
+
+		runEvent(
+			  event          = "admin.DataManager._deleteRecordAction"
+			, prePostExempt  = true
+			, private        = true
+			, eventArguments = args
+		);
 	}
 
 // PRIVATE HELPER METHODS

--- a/handlers/admin/datamanager/admin_dashboard.cfc
+++ b/handlers/admin/datamanager/admin_dashboard.cfc
@@ -4,7 +4,6 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 	property name="widgetService"        inject="adminDashboardWidgetService";
 	property name="datamanagerService"   inject="datamanagerService";
 	property name="presideObjectService" inject="presideObjectService";
-	property name="enumService"          inject="enumService";
 
 	variables.sidebarNavigation = true;
 	variables.infoCol3          = [];
@@ -53,7 +52,7 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 		var forSystem = isTrue( rc.systemOnly ?: "" );
 
 		if ( forSystem ) {
-			prc.gridFields       = [ "contexts", "name", "description", "datecreated" ];
+			prc.gridFields       = [ "name", "description", "datecreated" ];
 			prc.hiddenGridFields = prc.hiddenGridFields ?: [];
 			ArrayAppend( prc.hiddenGridFields, [ "view_access", "edit_access" ], true );
 		}
@@ -65,7 +64,7 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 			, icon   = "fa-tachometer"
 		} );
 
-		prc.hasSystemDashboards = prc.hasSystemDashboards ?: getPresideObject( "admin_dashboard" ).dataExists( filter={ is_system=true, owner="" } );
+		prc.hasSystemDashboards = prc.hasSystemDashboards ?: getPresideObject( "admin_dashboard" ).dataExists( filter={ is_system=true, owner="", contexts="" } );
 		if ( isTrue( prc.hasSystemDashboards ) ) {
 			ArrayAppend( prc.adminSidebarItems, {
 				  active = forSystem && ( curEvent == "admin.datamanager.object" ) && ( curObject == "admin_dashboard" )
@@ -90,45 +89,18 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 		prc.pageIcon           = "";
 	}
 
-	private string function listingViewlet( event, rc, prc, args={} ) {
-		var forSystem = isTrue( rc.systemOnly ?: "" );
-
-		if ( forSystem ) {
-			args.allRecordsLink       = event.buildAdminLink( objectName="admin_dashboard", queryString="systemOnly=true" );
-			args.categoryLinkBase     = event.buildAdminLink( objectName="admin_dashboard", queryString="systemOnly=true&activeCategoryId={activeCategoryId}" );
-			args.allListingCategories = enumService.listItems( enum="adminDashboardContexts" );
-			args.currentListingView   = runEvent(
-				  event          = "admin.dataManager._objectListingViewlet"
-				, private        = true
-				, prePostExempt  = true
-				, eventArguments = { args=args }
-			);
-
-			return renderView( view="/admin/datamanager/_listingWithCategories", args=args );
-		}
-
-		return super.listingViewlet( argumentCollection=arguments );
-	}
-
 	private string function getAdditionalQueryStringForBuildAjaxListingLink( event, rc, prc, args={} ) {
-		var qs = [];
-
 		if ( isTrue( rc.systemOnly ?: "" ) ) {
-			ArrayAppend( qs, "systemOnly=true" );
+			return "systemOnly=true";
 		}
 
-		if ( Len( rc.activeCategoryId ?: "" ) ) {
-			ArrayAppend( qs, "context=#UrlEncodedFormat( rc.activeCategoryId )#" );
-		}
-
-		return ArrayToList( qs, "&" );
+		return "";
 	}
 
 	private void function preFetchRecordsForGridListing( event, rc, prc, args={} ) {
 		args.extraFilters = args.extraFilters ?: [];
 
 		var systemOnly  = isTrue( rc.systemOnly ?: "" );
-		var contextVal  = Trim( rc.context ?: "" );
 		var adminUserId = event.getAdminUserId();
 
 		if ( !dashboardService.hasFullAccess( adminUserId ) ) {
@@ -154,17 +126,11 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 		}
 
 		if ( systemOnly ) {
-			ArrayAppend( args.extraFilters, { filter={ is_system=true } } );
+			ArrayAppend( args.extraFilters, { filter={ is_system=true, owner="", contexts="" } } );
 		} else {
 			ArrayAppend( args.extraFilters, { filter={ is_system=false } } );
 		}
 
-		if ( Len( contextVal ) ) {
-			ArrayAppend( args.extraFilters, {
-				  filter       = "admin_dashboard.contexts LIKE (:contexts)"
-				, filterParams = { contexts={ type="cf_sql_varchar", value="%#contextVal#%" } }
-			} );
-		}
 	}
 
 	private void function postFetchRecordsForGridListing( event, rc, prc, args={} ) {
@@ -307,7 +273,7 @@ component extends="preside.system.base.EnhancedDataManagerBase" {
 			, icon   = "fa-tachometer"
 		} ];
 
-		prc.hasSystemDashboards = prc.hasSystemDashboards ?: getPresideObject( "admin_dashboard" ).dataExists( filter={ is_system=true, owner="" } );
+		prc.hasSystemDashboards = prc.hasSystemDashboards ?: getPresideObject( "admin_dashboard" ).dataExists( filter={ is_system=true, owner="", contexts="" } );
 		if ( isTrue( prc.hasSystemDashboards ) ) {
 			ArrayAppend( customSidebarItems, {
 				  active = forSystem && ( curEvent == "admin.datamanager.object" ) && ( curObject == "admin_dashboard" )

--- a/handlers/admin/webflow/adminDashboardsAddWidget.cfc
+++ b/handlers/admin/webflow/adminDashboardsAddWidget.cfc
@@ -125,10 +125,12 @@ component {
 	}
 
 	private string function configWidget( event, rc, prc, webflowId, wfInstance, args={} ) {
-		var savedState      = args.state ?: {};
-		var preconfigConfig = IsJSON( savedState.import_code ?: "" ) ? DeserializeJSON( savedState.import_code ) : {};
+		var savedState       = args.state ?: {};
+		var preconfigConfig  = IsJSON( savedState.import_code ?: "" ) ? DeserializeJSON( savedState.import_code ) : {};
+		var wfInstanceArgs   = arguments.wfInstance.getInstanceArgs();
+		var wfInstanceSubRef = Trim( wfInstanceArgs.subreference ?: "" );
 
-		args.dashboardId = rc.dashboard ?: ( prc.recordId ?: "" );
+		args.dashboardId = rc.dashboard ?: ( prc.recordId ?: ( ListLen( wfInstanceSubRef, "_" ) > 1 ) ? ListLast( wfInstanceSubRef, "_" ) : ( submittedData.dashboardId ?: "" ) );
 		args.widgetId    = preconfigConfig.widgetId ?: ( savedState.widget ?: "" );
 		args.templateId  = "";
 

--- a/handlers/admin/webflow/adminDashboardsAddWidget.cfc
+++ b/handlers/admin/webflow/adminDashboardsAddWidget.cfc
@@ -1,9 +1,16 @@
 component {
-	property name="widgetService" inject="adminDashboardWidgetService";
-	property name="enumService"   inject="EnumService";
+	property name="widgetService"        inject="adminDashboardWidgetService";
+	property name="enumService"          inject="EnumService";
+	property name="dashboardService"     inject="adminDashboardService";
 
 	private struct function initState( event, rc, prc, args={}, instanceRef, webflowId, webflow ) {
-		return {};
+		var postAdd = Trim( rc.post_add_dashboard_url ?: "" );
+
+		if ( Len( postAdd ) && !dashboardService.isSafeAdminReturnUrl( postAdd ) ) {
+			postAdd = "";
+		}
+
+		return { post_add_dashboard_url=postAdd };
 	}
 
 	private string function selectType( event, rc, prc, webflowId, wfInstance, args={} ) {
@@ -179,6 +186,7 @@ component {
 		var wfInstanceSubRef = Trim( wfInstanceArgs.subreference ?: "" );
 
 		args.dashboardId = ( ListLen( wfInstanceSubRef, "_" ) > 1 ) ? ListLast( wfInstanceSubRef, "_" ) : ( savedState.dashboardId ?: "" );
+		args.post_add_dashboard_url = savedState.post_add_dashboard_url ?: "";
 
 		return renderView( view="/admin/webflow/adminDashboardsAddWidget/confirmation", args=args );
 	}

--- a/handlers/dbmigrations/adminDashboardDefaultSystemFieldValue.cfc
+++ b/handlers/dbmigrations/adminDashboardDefaultSystemFieldValue.cfc
@@ -1,0 +1,10 @@
+component {
+
+	private void function run() {
+		getPresideObject( "admin_dashboard" ).updateData(
+			  filter = "is_system IS NULL"
+			, data   = { is_system=false }
+		);
+	}
+
+}

--- a/handlers/generators/AdminDashboard.cfc
+++ b/handlers/generators/AdminDashboard.cfc
@@ -1,6 +1,12 @@
 component {
 
 	private string function owner( event, rc, prc, args={} ) {
+		var data = args.data ?: {};
+
+		if ( StructKeyExists( data, "owner" ) ) {
+			return data.owner;
+		}
+
 		return event.getAdminUserId();
 	}
 

--- a/handlers/renderers/content/AdminDashboardContexts.cfc
+++ b/handlers/renderers/content/AdminDashboardContexts.cfc
@@ -1,0 +1,16 @@
+/**
+ * @feature    admin
+ */
+component {
+
+	public string function default( event, rc, prc, args={} ) {
+		var rendered = [];
+		var contexts = ListToArray( args.data ?: "" );
+
+		for ( var context in contexts ) {
+			ArrayAppend( rendered, translateResource( uri="enum.adminDashboardContexts:#context#.label", defaultValue=context ) );
+		}
+
+		return ArrayToList( rendered, ", " );
+	}
+}

--- a/helpers/adminDashboardsHelpers.cfm
+++ b/helpers/adminDashboardsHelpers.cfm
@@ -1,5 +1,6 @@
 <cffunction name="renderAdminDashboard" access="public" returntype="string" output="false">
-<cfargument name="userGenerated" type="boolean" required="false" default="false" />
+	<cfargument name="userGenerated" type="boolean" required="false" default="false" />
+
 	<cfscript>
 		if ( arguments.userGenerated ) {
 			return getController().renderViewlet( event="admin.admindashboards.renderUserGeneratedDashboard", args=arguments );
@@ -7,4 +8,10 @@
 			return getController().renderViewlet( event="admin.admindashboards.renderDashboard", args=arguments );
 		}
 	</cfscript>
+</cffunction>
+
+<cffunction name="isSystemAdminDashboard" access="public" returntype="boolean" output="false">
+	<cfargument name="dashboardId" type="string" required="true" />
+
+	<cfreturn getSingleton( "adminDashboardService" ).isSystemDashboard( argumentCollection=arguments )>
 </cffunction>

--- a/i18n/admin/admindashboards/widget/dashboardDataFilter.properties
+++ b/i18n/admin/admindashboards/widget/dashboardDataFilter.properties
@@ -5,3 +5,5 @@ description=Display a grid of relevant information
 field.applies_to.title=Applies to
 field.filter.title=Filter
 field.grid_fields.title=Grid fields
+
+widget.cta_link.icon=fa-chevron-right

--- a/i18n/admindashboards.properties
+++ b/i18n/admindashboards.properties
@@ -1,6 +1,7 @@
 widget.failed.to.load.message=There was an error loading your dashboard content. Please try again or report the error to your administrators.
 configure.widget.dialog.title=Configure dashboard widget: {1}
 configform.widget_title.label=Widget title
+non.contextual.widgets.message=One or more widgets in this dashboard do not support contextual data display and may display incorrect or irrelevant information.
 
 no.config=<em>This widget has not yet been configured.</em>
 configure.widget.title=Configure this widget
@@ -25,3 +26,15 @@ group.all.label=All
 group.uncategorised.label=Custom
 
 item.tag.uncategorised.label=Custom
+
+selector.label=Dashboard:
+selector.current.default.label=Current dashboard
+
+selector.group.system.label=Templates
+selector.group.system.icon=fa-chart-pie
+
+selector.group.currentUser.label=Created by me
+selector.group.currentUser.icon=fa-user
+
+selector.group.viewAccess.label=View access only
+selector.group.viewAccess.icon=fa-eye

--- a/i18n/preside-objects/admin_dashboard.properties
+++ b/i18n/preside-objects/admin_dashboard.properties
@@ -10,6 +10,9 @@ field.name.title=Name
 field.description.title=Description
 field.dashboard_layout.title=Layout
 field.column_count.title=Columns
+field.contexts.title=Contexts
+field.is_system.title=System dashboard?
+field.system_id.title=System ID
 field.owner.title=Owner
 field.widgets.title=Widgets
 
@@ -45,6 +48,7 @@ viewtab.mydashboards.title=Created by me
 viewtab.mydashboards.iconClass=fa-tachometer green
 
 sidenav.all.label=All dashboards
+sidenav.systemdashboards.title=System dashboards
 sidenav.mydashboards.title=Created by me
 sidenav.mydashboards.iconClass=fa-user-circle
 sidenav.accessibledashboards.title=Shared with me

--- a/i18n/preside-objects/admin_dashboard.properties
+++ b/i18n/preside-objects/admin_dashboard.properties
@@ -59,6 +59,7 @@ gridlayout.editlayout.btn=Edit dashboard layout & widget
 gridlayout.edit.btn=Edit dashboard information
 gridlayout.clone.btn=Clone dashboard
 gridlayout.delete.btn=Delete dashboard
+gridlayout.delete.confirmation=Are you sure you want to delete the dashboard "{1}"? This action cannot be undone.
 
 gridlayout.save.btn=Save changes
 gridlayout.cancel.btn=Cancel

--- a/i18n/webflow/adminDashboardsAddWidget.properties
+++ b/i18n/webflow/adminDashboardsAddWidget.properties
@@ -15,6 +15,7 @@ step.selectWidget.field.widget.label=Widget
 step.selectWidget.header.search.placeholder=Type to search widgets
 step.selectWidget.no.widgets.msg=No available widget found.
 step.selectWidget.filters.group.label=Categories
+step.selectWidget.tag.contextual.label=Supports contextual display
 
 step.configWidget.label=Configure widget
 step.configWidget.title=Configure widget

--- a/interceptors/AdminDashboardsInterceptors.cfc
+++ b/interceptors/AdminDashboardsInterceptors.cfc
@@ -1,4 +1,5 @@
 component extends="coldbox.system.Interceptor" {
+	property name="adminDashboardService"       inject="delayedInjector:adminDashboardService";
 	property name="adminDashboardWidgetService" inject="delayedInjector:adminDashboardWidgetService";
 
 // PUBLIC
@@ -6,5 +7,6 @@ component extends="coldbox.system.Interceptor" {
 
 	public void function onApplicationStart( event, interceptData ) {
 		adminDashboardWidgetService.syncDashboardWidgetTemplates();
+		adminDashboardService.syncSystemDashboards();
 	}
 }

--- a/preside-objects/admin_dashboard.cfc
+++ b/preside-objects/admin_dashboard.cfc
@@ -13,8 +13,11 @@ component  {
 	property name="name"         type="string"  dbtype="varchar" maxlength="50" required=true uniqueIndexes="dashboardName";
 	property name="description"  type="string"  dbtype="varchar" maxlength="300";
 	property name="column_count" type="numeric" dbtype="int"     default=2;
+	property name="contexts"     type="string"  dbtype="varchar" maxlength="300"                  batcheditable=false adminRenderer="adminDashboardContexts";
+	property name="is_system"    type="boolean" dbtype="boolean" default=false indexes="issystem" batcheditable=false control="none"                                   cloneable=false;
+	property name="system_id"    type="string"  dbtype="varchar" maxlength="300"                  batcheditable=false control="none" uniqueIndexes="systemDashboardId" cloneable=false;
 
-	property name="owner"        relationship="many-to-one" relatedTo="security_user" required=true generate="insert" generator="adminDashboard.owner" cloneable=false;
+	property name="owner"        relationship="many-to-one" relatedTo="security_user" required=false generate="insert" generator="adminDashboard.owner" cloneable=false;
 	property name="widgets"      relationship="one-to-many" relatedto="admin_dashboard_widget" relationshipKey="dashboard" cloneable=true;
 
 	property name="view_access" type="string" dbtype="varchar" maxlength=10 enum="adminDashboardViewAccess" default="private";

--- a/services/AdminDashboardService.cfc
+++ b/services/AdminDashboardService.cfc
@@ -47,13 +47,16 @@ component {
 	}
 
 	public query function getUserDashboards(
-		  string  adminUserId  = $getAdminLoggedInUserId()
-		, array   extraFilters = []
-		, string  orderBy      = "name"
-		, numeric maxRows      = 0
+		  string  adminUserId        = $getAdminLoggedInUserId()
+		, array   extraFilters       = []
+		, string  orderBy            = "name"
+		, numeric maxRows            = 0
+		, boolean skipNoContextFilter = false
 	) {
 		_prepareNonSystemDashboardFilter( argumentCollection=arguments );
-		_prepareNoContextDashboardFilter( argumentCollection=arguments );
+		if ( !arguments.skipNoContextFilter ) {
+			_prepareNoContextDashboardFilter( argumentCollection=arguments );
+		}
 
 		return $getPresideObject( "admin_dashboard" ).selectData(
 			  filter       = { owner=arguments.adminUserId }
@@ -64,14 +67,17 @@ component {
 	}
 
 	public query function getUserAccessibleDashboards(
-		  string  adminUserId  = $getAdminLoggedInUserId()
-		, array   extraFilters = []
-		, string  orderBy      = "name"
-		, numeric maxRows      = 0
-		, string  groupBy      = "admin_dashboard.id"
+		  string  adminUserId         = $getAdminLoggedInUserId()
+		, array   extraFilters        = []
+		, string  orderBy             = "name"
+		, numeric maxRows             = 0
+		, string  groupBy             = "admin_dashboard.id"
+		, boolean skipNoContextFilter = false
 	) {
 		_prepareNonSystemDashboardFilter( argumentCollection=arguments );
-		_prepareNoContextDashboardFilter( argumentCollection=arguments );
+		if ( !arguments.skipNoContextFilter ) {
+			_prepareNoContextDashboardFilter( argumentCollection=arguments );
+		}
 
 		var adminUserGroups = _getAdminUserGroups( adminUserId=arguments.adminUserId );
 
@@ -154,7 +160,8 @@ component {
 			}
 		}
 
-		var userDashboards = getUserDashboards( argumentCollection=arguments, extraFilters=userExtraFilters );
+		var hasContext     = Len( context ) > 0;
+		var userDashboards = getUserDashboards( argumentCollection=arguments, extraFilters=userExtraFilters, skipNoContextFilter=hasContext );
 		if ( userDashboards.recordcount ) {
 			var userDashboardItems = [];
 
@@ -177,7 +184,7 @@ component {
 			} );
 		}
 
-		var accessDashboards = getUserAccessibleDashboards( argumentCollection=arguments, extraFilters=accessExtraFilters );
+		var accessDashboards = getUserAccessibleDashboards( argumentCollection=arguments, extraFilters=accessExtraFilters, skipNoContextFilter=hasContext );
 		if ( accessDashboards.recordcount ) {
 			var accessDashboardItems = [];
 
@@ -383,6 +390,102 @@ component {
 			, paramName = "adminDashboardEditLayout"
 			, value     = "true"
 		);
+	}
+
+	public string function buildDashboardShareLink(
+		  required string dashboardId
+		,          struct contextData = {}
+	) {
+		var ctx = Trim( arguments.contextData.context ?: "" );
+
+		if ( Len( ctx ) ) {
+			var viewlet = "admin.adminDashboards.context.#ctx#.dashboardShareLink";
+
+			if ( $getColdbox().viewletExists( viewlet ) ) {
+				var dashboardData             = getDashboard( dashboardId=arguments.dashboardId );
+				    dashboardData.contextData = arguments.contextData;
+
+				var customLink = $renderViewlet( event=viewlet, args=dashboardData );
+
+				if ( IsSimpleValue( customLink ) && Len( Trim( customLink ) ) ) {
+					return Trim( customLink );
+				}
+			}
+		}
+
+		return $getRequestContext().buildAdminLink( objectName="admin_dashboard", operation="sharing", recordId=arguments.dashboardId );
+	}
+
+	public string function buildDashboardEditRecordLink(
+		  required string dashboardId
+		,          struct contextData = {}
+	) {
+		var ctx = Trim( arguments.contextData.context ?: "" );
+
+		if ( Len( ctx ) ) {
+			var viewlet = "admin.adminDashboards.context.#ctx#.dashboardEditRecordLink";
+
+			if ( $getColdbox().viewletExists( viewlet ) ) {
+				var dashboardData             = getDashboard( dashboardId=arguments.dashboardId );
+				    dashboardData.contextData = arguments.contextData;
+
+				var customLink = $renderViewlet( event=viewlet, args=dashboardData );
+
+				if ( IsSimpleValue( customLink ) && Len( Trim( customLink ) ) ) {
+					return Trim( customLink );
+				}
+			}
+		}
+
+		return $getRequestContext().buildAdminLink( objectName="admin_dashboard", operation="editRecord", recordId=arguments.dashboardId );
+	}
+
+	public string function buildDashboardCloneLink(
+		  required string dashboardId
+		,          struct contextData = {}
+	) {
+		var ctx = Trim( arguments.contextData.context ?: "" );
+
+		if ( Len( ctx ) ) {
+			var viewlet = "admin.adminDashboards.context.#ctx#.dashboardCloneLink";
+
+			if ( $getColdbox().viewletExists( viewlet ) ) {
+				var dashboardData             = getDashboard( dashboardId=arguments.dashboardId );
+				    dashboardData.contextData = arguments.contextData;
+
+				var customLink = $renderViewlet( event=viewlet, args=dashboardData );
+
+				if ( IsSimpleValue( customLink ) && Len( Trim( customLink ) ) ) {
+					return Trim( customLink );
+				}
+			}
+		}
+
+		return $getRequestContext().buildAdminLink( objectName="admin_dashboard", operation="cloneRecord", recordId=arguments.dashboardId );
+	}
+
+	public string function buildDashboardDeleteLink(
+		  required string dashboardId
+		,          struct contextData = {}
+	) {
+		var ctx = Trim( arguments.contextData.context ?: "" );
+
+		if ( Len( ctx ) ) {
+			var viewlet = "admin.adminDashboards.context.#ctx#.dashboardDeleteLink";
+
+			if ( $getColdbox().viewletExists( viewlet ) ) {
+				var dashboardData             = getDashboard( dashboardId=arguments.dashboardId );
+				    dashboardData.contextData = arguments.contextData;
+
+				var customLink = $renderViewlet( event=viewlet, args=dashboardData );
+
+				if ( IsSimpleValue( customLink ) && Len( Trim( customLink ) ) ) {
+					return Trim( customLink );
+				}
+			}
+		}
+
+		return $getRequestContext().buildAdminLink( objectName="admin_dashboard", operation="deleteRecordAction", recordId=arguments.dashboardId );
 	}
 
 	public string function getValidatedAdminReturnUrlOrDefault(

--- a/services/AdminDashboardService.cfc
+++ b/services/AdminDashboardService.cfc
@@ -3,7 +3,8 @@
  * @singleton      true
  */
 component {
-	property name="permissionService" inject="PermissionService";
+	property name="permissionService"   inject="PermissionService";
+	property name="discoverDirectories" inject="presidecms:directories";
 
 // CONSTRUCTOR
 	/**
@@ -14,12 +15,45 @@ component {
 	}
 
 // PUBLIC API METHODS
+	public boolean function isSystemDashboard( required string dashboardId ) {
+		return $getPresideObject( "admin_dashboard" ).dataExists( filter={
+			  id        = arguments.dashboardId
+			, is_system = true
+		} );
+	}
+
+	public struct function getDashboard(
+		  required string dashboardId
+		,          array  extraFields = []
+	) {
+		return $getPresideObject( "admin_dashboard" ).selectData(
+			  id                = arguments.dashboardId
+			, returntype        = "singleRecordStruct"
+			, extraSelectFields = arguments.extraFields
+		);
+	}
+
+	public query function getSystemDashboards(
+		  array   extraFilters = []
+		, string  orderBy      = "name"
+		, numeric maxRows      = 0
+	) {
+		return $getPresideObject( "admin_dashboard" ).selectData(
+			  filter       = { is_system=true, owner="" }
+			, extraFilters = arguments.extraFilters
+			, orderBy      = arguments.orderBy
+			, maxRows      = arguments.maxRows
+		);
+	}
+
 	public query function getUserDashboards(
 		  string  adminUserId  = $getAdminLoggedInUserId()
 		, array   extraFilters = []
 		, string  orderBy      = "name"
 		, numeric maxRows      = 0
 	) {
+		_prepareNonSystemDashboardFilter( argumentCollection=arguments );
+
 		return $getPresideObject( "admin_dashboard" ).selectData(
 			  filter       = { owner=arguments.adminUserId }
 			, extraFilters = arguments.extraFilters
@@ -35,6 +69,8 @@ component {
 		, numeric maxRows      = 0
 		, string  groupBy      = "admin_dashboard.id"
 	) {
+		_prepareNonSystemDashboardFilter( argumentCollection=arguments );
+
 		var adminUserGroups = _getAdminUserGroups( adminUserId=arguments.adminUserId );
 
 		return $getPresideObject( "admin_dashboard" ).selectData(
@@ -53,8 +89,115 @@ component {
 		);
 	}
 
+	public struct function getDashboardsForSelector(
+		  string  adminUserId        = $getAdminLoggedInUserId()
+		, struct  contextData        = {}
+		, array   extraFilters       = []
+		, string  orderBy            = "admin_dashboard.name"
+		, numeric maxRows            = 3
+		, string  groupBy            = "admin_dashboard.id"
+		, string  currentDashboardId = ""
+		, boolean includeTemplates   = true
+		, boolean includeUser        = true
+		, boolean includeAccess      = true
+	) {
+		var activeDashboard     = {};
+		var availableDashboards = [];
+		var systemExtraFilters  = Duplicate( arguments.extraFilters );
+		var userExtraFilters    = Duplicate( arguments.extraFilters );
+		var accessExtraFilters  = Duplicate( arguments.extraFilters );
+
+		if ( Len( arguments.currentDashboardId ) ) {
+			activeDashboard = getDashboard( dashboardId=arguments.currentDashboardId, extraFields=[ "name as title" ] );
+
+			var currentDashboardFilter = {
+				  filter       = "admin_dashboard.id != :currentDashboardId"
+				, filterParams = { currentDashboardId={ type="cf_sql_varchar", value=arguments.currentDashboardId } }
+			};
+
+			ArrayAppend( systemExtraFilters, currentDashboardFilter );
+			ArrayAppend( userExtraFilters  , currentDashboardFilter );
+			ArrayAppend( accessExtraFilters, currentDashboardFilter );
+		}
+
+		var context = Trim( arguments.contextData.context ?: "" );
+		if ( Len( context ) ) {
+			var contextFilter = {
+				  filter       = "admin_dashboard.contexts LIKE (:contexts)"
+				, filterParams = { contexts={ type="cf_sql_varchar", value="%#context#%" } }
+			};
+
+			ArrayAppend( systemExtraFilters, contextFilter );
+			ArrayAppend( userExtraFilters  , contextFilter );
+			ArrayAppend( accessExtraFilters, contextFilter );
+		}
+
+		if ( arguments.includeTemplates ) {
+			var systemDashboards = getSystemDashboards( argumentCollection=arguments, extraFilters=systemExtraFilters );
+			if ( systemDashboards.recordcount ) {
+				var systemDashboardItems = [];
+
+				for ( var dashboard in systemDashboards ) {
+					ArrayAppend( systemDashboardItems, {
+						  id       = dashboard.id
+						, title    = dashboard.name
+						, subtitle = $helpers.abbreviate( dashboard.description ?: "", 60 )
+						, link     = _buildLinkForDashboard( dashboardId=dashboard.id, contextData=arguments.contextData )
+					} );
+				}
+
+				if ( ArrayLen( systemDashboardItems ) ) {
+					ArrayAppend( availableDashboards, { type="system", items=systemDashboardItems } );
+				}
+			}
+		}
+
+		var userDashboards = getUserDashboards( argumentCollection=arguments, extraFilters=userExtraFilters );
+		if ( userDashboards.recordcount ) {
+			var userDashboardItems = [];
+
+			for ( var dashboard in userDashboards ) {
+				ArrayAppend( userDashboardItems, {
+					  id       = dashboard.id
+					, title    = dashboard.name
+					, subtitle = $helpers.abbreviate( dashboard.description ?: "", 60 )
+					, link     = _buildLinkForDashboard( dashboardId=dashboard.id, contextData=arguments.contextData )
+				} );
+			}
+
+			if ( arguments.includeUser && ArrayLen( userDashboardItems ) ) {
+				ArrayAppend( availableDashboards, { type="currentUser", items=userDashboardItems } );
+			}
+
+			ArrayAppend( accessExtraFilters, {
+				  filter       = "admin_dashboard.id NOT IN (:excludedDashboardIds)"
+				, filterParams = { excludedDashboardIds={ type="cf_sql_varchar", value=ValueList( userDashboards.id ), list=true } }
+			} );
+		}
+
+		var accessDashboards = getUserAccessibleDashboards( argumentCollection=arguments, extraFilters=accessExtraFilters );
+		if ( accessDashboards.recordcount ) {
+			var accessDashboardItems = [];
+
+			for ( var dashboard in accessDashboards ) {
+				ArrayAppend( accessDashboardItems, {
+					  id       = dashboard.id
+					, title    = dashboard.name
+					, subtitle = $helpers.abbreviate( dashboard.description ?: "", 60 )
+					, link     = _buildLinkForDashboard( dashboardId=dashboard.id, contextData=arguments.contextData )
+				} );
+			}
+
+			if ( arguments.includeAccess && ArrayLen( accessDashboardItems ) ) {
+				ArrayAppend( availableDashboards, { type="viewAccess", items=accessDashboardItems } );
+			}
+		}
+
+		return { activeDashboard=activeDashboard, availableDashboards=availableDashboards };
+	}
+
 	public boolean function userCanViewDashboard( required string dashboardId, string adminUserId=$getAdminLoggedInUserId() ) {
-		if ( hasFullAccess( arguments.adminUserId ) ) {
+		if ( isSystemDashboard( arguments.dashboardId ) || hasFullAccess( arguments.adminUserId ) ) {
 			return true;
 		}
 
@@ -76,6 +219,10 @@ component {
 	}
 
 	public boolean function userCanEditDashboard( required string dashboardId, string adminUserId=$getAdminLoggedInUserId() ) {
+		if ( isSystemDashboard( arguments.dashboardId ) ) {
+			return false;
+		}
+
 		if ( hasFullAccess( arguments.adminUserId ) ) {
 			return true;
 		}
@@ -91,6 +238,10 @@ component {
 	}
 
 	public boolean function userCanShareDashboard( required string dashboardId, string adminUserId=$getAdminLoggedInUserId() ) {
+		if ( isSystemDashboard( arguments.dashboardId ) ) {
+			return false;
+		}
+
 		if ( hasFullAccess( arguments.adminUserId ) ) {
 			return true;
 		}
@@ -101,6 +252,10 @@ component {
 	}
 
 	public boolean function userCanDeleteDashboard( required string dashboardId, string adminUserId=$getAdminLoggedInUserId() ) {
+		if ( isSystemDashboard( arguments.dashboardId ) ) {
+			return false;
+		}
+
 		if ( hasFullAccess( arguments.adminUserId ) ) {
 			return true;
 		}
@@ -120,12 +275,135 @@ component {
 		);
 	}
 
+	public void function syncSystemDashboards() {
+		var coldbox      = $getColdbox();
+		var dashboardDao = $getPresideObject( "admin_dashboard" );
+		var widgetDao    = $getPresideObject( "admin_dashboard_widget" );
+		var handlersPath = "/handlers/admin/adminDashboards/dashboard";
+		var i18nBase     = "admin.adminDashboards.dashboard.";
+		var dashboardIds = [];
+
+		for ( var dir in discoverDirectories ) {
+			dir = ReReplace( dir, "/$", "" );
+
+			var handlers = DirectoryList( dir & handlersPath, false, "query", "*.cfc" );
+			for ( var handler in handlers ) {
+
+				if ( handler.type eq "File" ) {
+					var dashboardId = ReReplace( handler.name, "\.cfc$", "" );
+					var recordId     = dashboardId;
+
+					if ( Len( recordId ) > 32 ) {
+						recordId = Left( dashboardId, 24 ) & ListFirst( CreateUUID(), "-" );
+					}
+
+					var dashboardExists = dashboardDao.dataExists( filter={ id=recordId, is_system=true } );
+					var dashboardData   = {
+						  name        = $translateResource( uri="#i18nBase##dashboardId#:title", defaultValue=dashboardId )
+						, description = $translateResource( uri="#i18nBase##dashboardId#:description", defaultValue="" )
+						, is_system   = true
+						, system_id   = dashboardId
+						, view_access = "public"
+						, owner       = ""
+					};
+
+					dashboardData.contexts = _prepareSystemDashboardField( dashboardId, "contexts", dashboardData );
+					dashboardData.widgets  = _prepareSystemDashboardField( dashboardId, "widgets", dashboardData );
+
+					if ( IsArray( dashboardData.widgets ) && ArrayLen( dashboardData.widgets ) ) {
+						try {
+							if ( dashboardExists ) {
+								dashboardDao.updateData( id=recordId, data=dashboardData );
+							} else {
+								dashboardData.id = recordId;
+
+								dashboardDao.insertData( data=dashboardData );
+							}
+
+							widgetDao.deleteData( filter={ dashboard=recordId } );
+
+							for ( var widgetData in dashboardData.widgets ) {
+								widgetData.dashboard = recordId;
+
+								widgetDao.insertData( data=widgetData );
+							}
+
+							ArrayAppend( dashboardIds, recordId );
+						} catch ( any e ) {
+							$raiseError(e);
+						}
+					}
+				}
+			}
+		}
+
+		if ( ArrayLen( dashboardIds ) ) {
+			dashboardDao.deleteData(
+				  filter       = "id NOT IN (:ids) AND is_system = :is_system"
+				, filterParams = {
+					  ids       = { type="cf_sql_varchar", value=ArrayToList( dashboardIds ), list=true }
+					, is_system = true
+				}
+			);
+		}
+	}
+
 // PRIVATE HELPERS
 	private string function _getAdminUserGroups( required string adminUserId ) {
 		return $getPresideObject( "security_group" ).selectData(
 			  filter       = { "users.id"=arguments.adminUserId }
 			, selectFields = [ "id" ]
 		).valueList( "id" );
+	}
+
+	private any function _prepareSystemDashboardField(
+		  required string dashboardId
+		, required string viewletName
+		,          struct viewletArgs  = {}
+		,          string defaultvalue = ""
+	) {
+		var prepared    = arguments.defaultvalue;
+		var fullViewlet = "admin.adminDashboards.dashboard.#dashboardId#.#viewletName#";
+
+		if ( $getColdbox().viewletExists( fullViewlet ) ) {
+			prepared = $renderViewlet( event=fullViewlet, args=viewletArgs );
+		}
+
+		return prepared;
+	}
+
+	private array function _prepareNonSystemDashboardFilter( required array extraFilters ) {
+		ArrayAppend( arguments.extraFilters, { filter={ is_system=false } } );
+
+		return arguments.extraFilters;
+	}
+
+	private string function _buildLinkForDashboard(
+		  required string dashboardId
+		,          struct contextData = {}
+	) {
+		if ( isSystemDashboard( dashboardId=arguments.dashboardId ) ) {
+			var dashboardData             = getDashboard( dashboardId=arguments.dashboardId );
+			    dashboardData.contextData = arguments.contextData;
+
+			var customLink = _prepareSystemDashboardField( arguments.dashboardId, "dashboardLink", dashboardData );
+			if ( IsSimpleValue( customLink ) && Len( customLink ) ) {
+				return customLink;
+			}
+		} else if ( Len( Trim( arguments.contextData.context ?: "" ) ) ) {
+			var fullViewlet                = "admin.adminDashboards.context.#arguments.contextData.context#.dashboardLink";
+			var dashboardData             = getDashboard( dashboardId=arguments.dashboardId );
+			    dashboardData.contextData = arguments.contextData;
+
+			if ( $getColdbox().viewletExists( fullViewlet ) ) {
+				var customLink = $renderViewlet( event=fullViewlet, args=dashboardData );
+				if ( IsSimpleValue( customLink ) && Len( customLink ) ) {
+					return customLink;
+				}
+			}
+		}
+
+		return $getRequestContext().buildAdminLink( objectName="admin_dashboard", recordId=arguments.dashboardId );
 	}
 
 // GETTERS AND SETTERS

--- a/services/AdminDashboardService.cfc
+++ b/services/AdminDashboardService.cfc
@@ -348,6 +348,66 @@ component {
 		}
 	}
 
+	public string function buildDashboardViewLink(
+		  required string dashboardId
+		,          struct contextData = {}
+	) {
+		return _buildLinkForDashboard( argumentCollection=arguments );
+	}
+
+	public string function buildDashboardEditLayoutLink(
+		  required string dashboardId
+		,          struct contextData = {}
+	) {
+		var ctx = Trim( arguments.contextData.context ?: "" );
+
+		if ( Len( ctx ) ) {
+			var editViewlet = "admin.adminDashboards.context.#ctx#.dashboardEditLayoutLink";
+
+			if ( $getColdbox().viewletExists( editViewlet ) ) {
+				var dashboardData             = getDashboard( dashboardId=arguments.dashboardId );
+				    dashboardData.contextData = arguments.contextData ?: {};
+
+				var customEditLink = $renderViewlet( event=editViewlet, args=dashboardData );
+
+				if ( IsSimpleValue( customEditLink ) && Len( Trim( customEditLink ) ) ) {
+					return Trim( customEditLink );
+				}
+			}
+		}
+
+		return _appendQueryParam(
+			  url       = buildDashboardViewLink( dashboardId=arguments.dashboardId, contextData=arguments.contextData ?: {} )
+			, paramName = "adminDashboardEditLayout"
+			, value     = "true"
+		);
+	}
+
+	public string function getValidatedAdminReturnUrlOrDefault(
+		  required string candidateUrl
+		, required string defaultUrl
+	) {
+		var trimmed = Trim( arguments.candidateUrl );
+
+		if ( Len( trimmed ) && isSafeAdminReturnUrl( trimmed ) ) {
+			return trimmed;
+		}
+
+		return arguments.defaultUrl;
+	}
+
+	public boolean function isSafeAdminReturnUrl( required string url ) {
+		var path = Trim( arguments.url );
+
+		if ( !Len( path ) ) {
+			return false;
+		}
+
+		var prefix = _getAdminUrlPathPrefix();
+
+		return Len( prefix ) && Left( path, Len( prefix ) ) == prefix;
+	}
+
 // PRIVATE HELPERS
 	private string function _getAdminUserGroups( required string adminUserId ) {
 		return $getPresideObject( "security_group" ).selectData(
@@ -404,6 +464,32 @@ component {
 		}
 
 		return $getRequestContext().buildAdminLink( objectName="admin_dashboard", recordId=arguments.dashboardId );
+	}
+
+	private string function _appendQueryParam(
+		  required string url
+		, required string paramName
+		, required string value
+	) {
+		var separator = Find( "?", arguments.url ) ? "&" : "?";
+
+		return arguments.url & separator & arguments.paramName & "=" & UrlEncodedFormat( arguments.value );
+	}
+
+	private string function _getAdminUrlPathPrefix() {
+		var sample = ListFirst( $getRequestContext().buildAdminLink( linkTo="index" ), "?" );
+
+		while ( Len( sample ) && Right( sample, 1 ) == "/" ) {
+			sample = Left( sample, Len( sample ) - 1 );
+		}
+
+		if ( ReFind( "/[^/]+$", sample ) ) {
+			var stripped = ReReplace( sample, "/[^/]+$", "" );
+
+			return Len( stripped ) ? stripped : sample;
+		}
+
+		return sample;
 	}
 
 // GETTERS AND SETTERS

--- a/services/AdminDashboardService.cfc
+++ b/services/AdminDashboardService.cfc
@@ -53,6 +53,7 @@ component {
 		, numeric maxRows      = 0
 	) {
 		_prepareNonSystemDashboardFilter( argumentCollection=arguments );
+		_prepareNoContextDashboardFilter( argumentCollection=arguments );
 
 		return $getPresideObject( "admin_dashboard" ).selectData(
 			  filter       = { owner=arguments.adminUserId }
@@ -70,6 +71,7 @@ component {
 		, string  groupBy      = "admin_dashboard.id"
 	) {
 		_prepareNonSystemDashboardFilter( argumentCollection=arguments );
+		_prepareNoContextDashboardFilter( argumentCollection=arguments );
 
 		var adminUserGroups = _getAdminUserGroups( adminUserId=arguments.adminUserId );
 
@@ -434,6 +436,12 @@ component {
 
 	private array function _prepareNonSystemDashboardFilter( required array extraFilters ) {
 		ArrayAppend( arguments.extraFilters, { filter={ is_system=false } } );
+
+		return arguments.extraFilters;
+	}
+
+	private array function _prepareNoContextDashboardFilter( required array extraFilters ) {
+		ArrayAppend( arguments.extraFilters, { filter={ contexts="" } } );
 
 		return arguments.extraFilters;
 	}

--- a/services/AdminDashboardWidgetService.cfc
+++ b/services/AdminDashboardWidgetService.cfc
@@ -94,8 +94,9 @@ component {
 
 	public struct function renderUserGeneratedDashboard(
 		  required string  dashboardId
-		,          boolean allowEditing = true
-		,          struct  contextData  = {}
+		,          boolean allowEditing          = true
+		,          struct  contextData           = {}
+		,          string  deleteWidgetReturnUrl = ""
 	) {
 		var dashboard     = $getPresideObject( "admin_dashboard" ).selectData( id=arguments.dashboardId );
 		var savedWidgets  = $getPresideObject( "admin_dashboard_widget" ).selectData(
@@ -130,12 +131,13 @@ component {
 			widget.contextData.canEditDashboard = canEdit;
 
 			widgets[ widget.column ].append( renderWidgetContainer(
-				  dashboardId      = arguments.dashboardId
-				, widgetId         = widget.id
-				, contextData      = _namespaceContextData( widget.contextData )
-				, configInstanceId = widget.configInstanceId
-				, title            = widget.title ?: ""
-				, ajax             = widget.ajax
+				  dashboardId           = arguments.dashboardId
+				, widgetId              = widget.id
+				, contextData           = _namespaceContextData( widget.contextData )
+				, configInstanceId      = widget.configInstanceId
+				, title                 = widget.title ?: ""
+				, ajax                  = widget.ajax
+				, deleteWidgetReturnUrl = arguments.deleteWidgetReturnUrl
 			) );
 		}
 
@@ -147,9 +149,11 @@ component {
 
 	public struct function renderUserGeneratedGridDashboard(
 		  required string  dashboardId
-		,          boolean allowEditing    = true
-		,          struct  contextData     = {}
-		,          boolean showTempWidgets = false
+		,          boolean allowEditing          = true
+		,          struct  contextData           = {}
+		,          boolean showTempWidgets       = false
+		,          string  deleteWidgetReturnUrl = ""
+		,          string  dashboardLayoutAction = ""
 	) {
 		var dashboard           = $getPresideObject( "admin_dashboard" ).selectData( id=arguments.dashboardId );
 		var widget              = {};
@@ -204,21 +208,25 @@ component {
 
 			widget.contextData.canEditDashboard = canEdit;
 
-			ArrayAppend( widgets, {
-				  title              = savedWidget.title
-				, supportContext     = isWidgetSupportContext( widget.id )
-				, gridConfig         = gridConfig
-				, editTempGridConfig = editTempGridConfig
-				, html               = renderWidgetContainer(
-					  dashboardId      = arguments.dashboardId
-					, widgetId         = widget.id
-					, contextData      = _namespaceContextData( widget.contextData )
-					, configInstanceId = widget.configInstanceId
-					, title            = widget.title ?: ""
-					, ajax             = widget.ajax
-					, layout           = "grid"
-				)
-			} );
+			if ( userCanViewWidget( widgetId=widget.id, widgetConfig=widget ) ) {
+				ArrayAppend( widgets, {
+					  title              = savedWidget.title
+					, supportContext     = isWidgetSupportContext( widgetId=widget.id, widgetConfig=widget )
+					, gridConfig         = gridConfig
+					, editTempGridConfig = editTempGridConfig
+					, html               = renderWidgetContainer(
+						  dashboardId           = arguments.dashboardId
+						, widgetId              = widget.id
+						, contextData           = _namespaceContextData( widget.contextData )
+						, configInstanceId      = widget.configInstanceId
+						, title                 = widget.title ?: ""
+						, ajax                  = widget.ajax
+						, layout                = "grid"
+						, deleteWidgetReturnUrl = arguments.deleteWidgetReturnUrl
+						, dashboardLayoutAction = arguments.dashboardLayoutAction
+					)
+				} );
+			}
 		}
 
 		dashboardArgs.widgets = widgets;
@@ -236,6 +244,8 @@ component {
 		,          string  title            = ""
 		,          boolean ajax             = true
 		,          string  layout           = "default"
+		,          string  deleteWidgetReturnUrl = ""
+		,          string  dashboardLayoutAction = ""
 	) {
 		var instanceId             = "dashboard-widget-" & LCase( Hash( arguments.dashboardId & arguments.widgetId & SerializeJson( arguments.contextData ) ) );
 		var menuViewlet            = "admin.admindashboards.widget.#arguments.widgetId#.additionalMenu";
@@ -289,6 +299,8 @@ component {
 			, additionalMenu         = additionalMenu
 			, content                = content
 			, layout                 = arguments.layout
+			, deleteWidgetReturnUrl  = arguments.deleteWidgetReturnUrl
+			, dashboardLayoutAction  = arguments.dashboardLayoutAction
 		};
 
 		$announceInterception( "onRenderAdminWidgetContainer", args );
@@ -316,6 +328,11 @@ component {
 
 		if ( isUserDashboard ) {
 			formName = _getFormsService().getMergedFormName( formName, "admin.admindashboards.config" );
+
+			var contextFormName = "admin.admindashboards.widget.#arguments.widgetId#.userContext";
+			if ( _getFormsService().formExists( contextFormName ) ) {
+				formName = _getFormsService().getMergedFormName( formName, contextFormName );
+			}
 		}
 
 		var formArgs = { formName=formName, widget=arguments, isUserDashboard=isUserDashboard };
@@ -436,7 +453,10 @@ component {
 		return IsStruct( result ) ? result : {};
 	}
 
-	public boolean function userCanViewWidget( required string widgetId ) {
+	public boolean function userCanViewWidget(
+		  required string widgetId
+		,          struct widgetConfig = {}
+	) {
 		var coldbox         = $getColdbox();
 		var permissionEvent = "admin.admindashboards.widget.#widgetId#.hasPermission";
 		var result          = true;
@@ -446,6 +466,7 @@ component {
 				  event         = permissionEvent
 				, private       = true
 				, prePostExempt = true
+				, eventArguments = { args=arguments.widgetConfig }
 			);
 		}
 
@@ -468,7 +489,10 @@ component {
 		return $helpers.isTrue( result ?: "" );
 	}
 
-	public boolean function isWidgetSupportContext( required string widgetId ) {
+	public boolean function isWidgetSupportContext(
+		  required string widgetId
+		,          struct widgetConfig = {}
+	) {
 		var coldbox      = $getColdbox();
 		var viewletEvent = "admin.admindashboards.widget.#widgetId#.isWidgetSupportContext";
 		var result       = false;
@@ -478,6 +502,7 @@ component {
 				  event         = viewletEvent
 				, private       = true
 				, prePostExempt = true
+				, eventArguments = { args=arguments.widgetConfig }
 			);
 		}
 

--- a/services/AdminDashboardWidgetService.cfc
+++ b/services/AdminDashboardWidgetService.cfc
@@ -197,10 +197,17 @@ component {
 				, contextData      = IsJSON( savedWidget.config ) ? DeserializeJSON( savedWidget.config ) : {}
 				, ajax             = true
 			};
+
+			if ( !StructIsEmpty( arguments.contextData ) ) {
+				StructAppend( widget.contextData, arguments.contextData );
+			}
+
 			widget.contextData.canEditDashboard = canEdit;
 
-			widgets.append( {
-				  gridConfig         = gridConfig
+			ArrayAppend( widgets, {
+				  title              = savedWidget.title
+				, supportContext     = isWidgetSupportContext( widget.id )
+				, gridConfig         = gridConfig
 				, editTempGridConfig = editTempGridConfig
 				, html               = renderWidgetContainer(
 					  dashboardId      = arguments.dashboardId
@@ -453,6 +460,22 @@ component {
 		if ( coldbox.handlerExists( isUserDashboardWidgetEvent ) ) {
 			result = coldbox.runEvent(
 				  event         = isUserDashboardWidgetEvent
+				, private       = true
+				, prePostExempt = true
+			);
+		}
+
+		return $helpers.isTrue( result ?: "" );
+	}
+
+	public boolean function isWidgetSupportContext( required string widgetId ) {
+		var coldbox      = $getColdbox();
+		var viewletEvent = "admin.admindashboards.widget.#widgetId#.isWidgetSupportContext";
+		var result       = false;
+
+		if ( coldbox.handlerExists( viewletEvent ) ) {
+			result = coldbox.runEvent(
+				  event         = viewletEvent
 				, private       = true
 				, prePostExempt = true
 			);

--- a/services/AdminDashboardWidgetService.cfc
+++ b/services/AdminDashboardWidgetService.cfc
@@ -356,6 +356,13 @@ component {
 			StructAppend( renderFormArgs.savedData, arguments.configData );
 		}
 
+		if ( _isUserGeneratedDashboard( arguments.dashboardId ) && !Len( renderFormArgs.savedData.widget_title ?: "" ) ) {
+			var defaultTitle = getWidgetDefaultTitle( dashboardId=arguments.dashboardId, widgetId=arguments.widgetId );
+			if ( Len( defaultTitle ) ) {
+				renderFormArgs.savedData.widget_title = defaultTitle;
+			}
+		}
+
 		$announceInterception( "onRenderWidgetConfigForm", renderFormArgs );
 
 		return _getFormsService().renderForm( argumentCollection=renderFormArgs );
@@ -685,6 +692,38 @@ component {
 		var title     = baseTitle;
 		var dao       = $getPresideObject( "admin_dashboard_widget" );
 
+		var filter    = { dashboard=arguments.dashboardId, title=title };
+		var increment = 0;
+
+		while( dao.dataExists( filter=filter ) ) {
+			title = baseTitle & " (#++increment#)";
+			filter.title = title;
+		}
+
+		return title;
+	}
+
+	public string function getWidgetDefaultTitle(
+		  required string dashboardId
+		, required string widgetId
+	) {
+		var baseTitle = "";
+		var viewlet   = "admin.admindashboards.widget.#arguments.widgetId#.getDefaultTitle";
+
+		if ( $getColdbox().viewletExists( viewlet ) ) {
+			baseTitle = $renderViewlet( event=viewlet, args={ dashboardId=arguments.dashboardId } );
+		}
+
+		if ( !Len( baseTitle ) ) {
+			baseTitle = $translateResource( uri="admin.admindashboards.widget.#arguments.widgetId#:default.title", defaultValue="" );
+		}
+
+		if ( !Len( baseTitle ) ) {
+			return "";
+		}
+
+		var title     = baseTitle;
+		var dao       = $getPresideObject( "admin_dashboard_widget" );
 		var filter    = { dashboard=arguments.dashboardId, title=title };
 		var increment = 0;
 

--- a/views/admin/admindashboards/_dashboard.cfm
+++ b/views/admin/admindashboards/_dashboard.cfm
@@ -3,6 +3,8 @@
 </cfscript>
 
 <cfoutput>
+	#renderViewlet( event="admin.adminDashboards.renderDashboardHeader", args=args )#
+
 	<div class="admin-dashboard-container" data-dashboard-id="#args.dashboardId#">
 		<div class="row">#widgets#</div>
 

--- a/views/admin/admindashboards/dashboardSelector/_itemList.cfm
+++ b/views/admin/admindashboards/dashboardSelector/_itemList.cfm
@@ -1,0 +1,20 @@
+<cfscript>
+	icon    = args.icon    ?: "";
+	heading = args.heading ?: "";
+	items   = args.items   ?: [];
+</cfscript>
+<cfoutput>
+	<h6>
+		<cfif Len( icon )><i class="fa #icon#"></i></cfif> #heading#
+	</h6>
+	<ul>
+		<cfloop array="#items#" item="item">
+			<li class="dashboard-list-item" >
+				<a href="##">
+					<span class="dashboard-title">#item.title#</span>
+					<cfif Len( item.subtitle ?: "" )><span class="dashboard-subtitle">#item.subtitle#</span></cfif>
+				</a>
+			</li>
+		</cfloop>
+	</ul>
+</cfoutput>

--- a/views/admin/admindashboards/dashboardSelector/_itemList.cfm
+++ b/views/admin/admindashboards/dashboardSelector/_itemList.cfm
@@ -1,20 +1,27 @@
 <cfscript>
-	icon    = args.icon    ?: "";
-	heading = args.heading ?: "";
+	type    = args.type    ?: "";
+	heading = args.heading ?: translateResource( uri="admindashboards:selector.group.#type#.label", defaultValue="" );
+	icon    = args.icon    ?: translateResource( uri="admindashboards:selector.group.#type#.icon", defaultValue="" );
 	items   = args.items   ?: [];
 </cfscript>
+
 <cfoutput>
-	<h6>
-		<cfif Len( icon )><i class="fa #icon#"></i></cfif> #heading#
-	</h6>
-	<ul>
-		<cfloop array="#items#" item="item">
-			<li class="dashboard-list-item" >
-				<a href="##">
-					<span class="dashboard-title">#item.title#</span>
-					<cfif Len( item.subtitle ?: "" )><span class="dashboard-subtitle">#item.subtitle#</span></cfif>
-				</a>
-			</li>
-		</cfloop>
-	</ul>
+	<cfif ArrayLen( items )>
+		<cfif Len( heading )>
+			<h6><cfif Len( icon )><i class="fa #icon#"></i></cfif> #heading#</h6>
+		</cfif>
+
+		<ul>
+			<cfloop array="#items#" item="item">
+				<cfset hasLink = Len( item.link ?: "" ) />
+
+				<li class="dashboard-list-item">
+					<a class="#hasLink ? "" : "disabled"#" href="#hasLink ? item.link : "##"#">
+						<span class="dashboard-title">#item.title#</span>
+						<cfif Len( item.subtitle ?: "" )><span class="dashboard-subtitle">#item.subtitle#</span></cfif>
+					</a>
+				</li>
+			</cfloop>
+		</ul>
+	</cfif>
 </cfoutput>

--- a/views/admin/admindashboards/dashboardSelector/index.cfm
+++ b/views/admin/admindashboards/dashboardSelector/index.cfm
@@ -1,54 +1,26 @@
 <cfscript>
-	i18nDashboardSelectorLabel = "Dashboard:";
-
-	// Static example, please update accordingly in the proper BE implementation
-	activeDashboard = { title="Conference", subTitle="Description goes here" }
-
-	staticDashboardList   = [
-		{
-			  icon    = "fa-chart-pie"
-			, heading = "Templates"
-			, items   = [
-				  { title="Conference"  , subTitle="Description goes here", active=true }
-				, { title="Zoom webinar", subTitle="Description goes here" }
-				, { title="Post event"  , subTitle="Description goes here" }
-			]
-		}
-		, {
-			  icon    = "fa-user"
-			, heading = "Created by me"
-			, items   = [
-				  { title="Dashboard name", subTitle="Description goes here" }
-				, { title="Dashboard name", subTitle="Description goes here" }
-				, { title="Dashboard name", subTitle="Description goes here" }
-			]
-		}
-		, {
-			  icon    = "fa-eye"
-			, heading = "View access only"
-			, items   = [
-				  { title="Dashboard name", subTitle="Description goes here" }
-				, { title="Dashboard name", subTitle="Description goes here" }
-				, { title="Dashboard name", subTitle="Description goes here" }
-			]
-		}
-	]
+	activeDashboard     = args.activeDashboard     ?: {};
+	availableDashboards = args.availableDashboards ?: [];
 </cfscript>
 
 <cfoutput>
 	<div class="dashboard-selector">
-		<span class="dashboard-selector-label">#i18nDashboardSelectorLabel#</span>
+		<span class="dashboard-selector-label">#translateResource( uri="admindashboards:selector.label" )#</span>
+
 		<div class="dropdown">
 			<button id="dashboard-selector" type="button" class="btn btn-light" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				#activeDashboard.title# <span class="caret"></span>
+				#activeDashboard.title ?: translateResource( uri="admindashboards:selector.current.default.label" )# <span class="caret"></span>
 			</button>
-			<ul class="dropdown-menu dropdown-menu-dashboard" aria-labelledby="dashboard-selector">
-				<cfloop array="#staticDashboardList#" item="dashboardList">
-					<li>
-						#renderView( view="/admin/admindashboards/dashboardSelector/_itemList", args=dashboardList )#
-					</li>
-				</cfloop>
-			</ul>
+
+			<cfif ArrayLen( availableDashboards )>
+				<ul class="dropdown-menu dropdown-menu-dashboard" aria-labelledby="dashboard-selector">
+					<cfloop array="#availableDashboards#" item="dashboard">
+						<li>
+							#renderView( view="/admin/admindashboards/dashboardSelector/_itemList", args=dashboard )#
+						</li>
+					</cfloop>
+				</ul>
+			</cfif>
 		</div>
 	</div>
 </cfoutput>

--- a/views/admin/admindashboards/dashboardSelector/index.cfm
+++ b/views/admin/admindashboards/dashboardSelector/index.cfm
@@ -1,0 +1,54 @@
+<cfscript>
+	i18nDashboardSelectorLabel = "Dashboard:";
+
+	// Static example, please update accordingly in the proper BE implementation
+	activeDashboard = { title="Conference", subTitle="Description goes here" }
+
+	staticDashboardList   = [
+		{
+			  icon    = "fa-chart-pie"
+			, heading = "Templates"
+			, items   = [
+				  { title="Conference"  , subTitle="Description goes here", active=true }
+				, { title="Zoom webinar", subTitle="Description goes here" }
+				, { title="Post event"  , subTitle="Description goes here" }
+			]
+		}
+		, {
+			  icon    = "fa-user"
+			, heading = "Created by me"
+			, items   = [
+				  { title="Dashboard name", subTitle="Description goes here" }
+				, { title="Dashboard name", subTitle="Description goes here" }
+				, { title="Dashboard name", subTitle="Description goes here" }
+			]
+		}
+		, {
+			  icon    = "fa-eye"
+			, heading = "View access only"
+			, items   = [
+				  { title="Dashboard name", subTitle="Description goes here" }
+				, { title="Dashboard name", subTitle="Description goes here" }
+				, { title="Dashboard name", subTitle="Description goes here" }
+			]
+		}
+	]
+</cfscript>
+
+<cfoutput>
+	<div class="dashboard-selector">
+		<span class="dashboard-selector-label">#i18nDashboardSelectorLabel#</span>
+		<div class="dropdown">
+			<button id="dashboard-selector" type="button" class="btn btn-light" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				#activeDashboard.title# <span class="caret"></span>
+			</button>
+			<ul class="dropdown-menu dropdown-menu-dashboard" aria-labelledby="dashboard-selector">
+				<cfloop array="#staticDashboardList#" item="dashboardList">
+					<li>
+						#renderView( view="/admin/admindashboards/dashboardSelector/_itemList", args=dashboardList )#
+					</li>
+				</cfloop>
+			</ul>
+		</div>
+	</div>
+</cfoutput>

--- a/views/admin/admindashboards/layoutGrid/_inlineDashboardEditToolbar.cfm
+++ b/views/admin/admindashboards/layoutGrid/_inlineDashboardEditToolbar.cfm
@@ -9,6 +9,17 @@
 	editLayoutBtn  = translateResource( "preside-objects.admin_dashboard:gridlayout.editlayout.btn" );
 	cancelBtn      = translateResource( uri="preside-objects.admin_dashboard:gridlayout.cancel.btn" );
 	saveBtn        = translateResource( uri="preside-objects.admin_dashboard:gridlayout.save.btn" );
+
+	canShare       = isTrue( args.inlineToolbarCanShareDashboard  ?: "" );
+	canEditRecord  = isTrue( args.inlineToolbarCanEditDashboard   ?: "" );
+	canClone       = isTrue( args.inlineToolbarCanCloneDashboard  ?: "" );
+	canDelete      = isTrue( args.inlineToolbarCanDeleteDashboard ?: "" );
+
+	shareLink      = args.inlineToolbarShareLink      ?: "";
+	editRecordLink = args.inlineToolbarEditRecordLink ?: "";
+	cloneLink      = args.inlineToolbarCloneLink      ?: "";
+	deleteLink     = args.inlineToolbarDeleteLink     ?: "";
+	showDropdown   = ( canShare || canEditRecord || canClone || canDelete );
 </cfscript>
 
 <cfoutput>
@@ -16,7 +27,50 @@
 		<div class="admin-dashboard-inline-edit-toolbar clearfix">
 			<div class="pull-right btn-toolbar">
 				<cfif layoutAction == "viewrecord">
-					<a class="btn btn-primary btn-sm" href="#HtmlEditFormat( editLink )#">#HtmlEditFormat( editLayoutBtn )#</a>
+					<cfif canEditRecord and Len( editLink )>
+						<a class="btn btn-primary btn-sm" href="#HtmlEditFormat( editLink )#">#HtmlEditFormat( editLayoutBtn )#</a>
+					</cfif>
+
+					<cfif showDropdown>
+						<div class="btn-group pull-right">
+							<button type="button" class="btn btn-primary-invert btn-sm dropdown-toggle" data-toggle="dropdown">
+								<i class="fa fa-fw fa-ellipsis-v"></i>
+							</button>
+							<ul class="dropdown-menu dropdown-menu-right">
+								<cfif canShare and Len( shareLink )>
+									<li>
+										<a href="#HtmlEditFormat( shareLink )#">
+											<i class="fa fa-fw fa-users"></i> #HtmlEditFormat( translateResource( uri="preside-objects.admin_dashboard:sharing.btn" ) )#
+										</a>
+									</li>
+								</cfif>
+								<cfif canEditRecord and Len( editRecordLink )>
+									<li>
+										<a href="#HtmlEditFormat( editRecordLink )#">
+											<i class="fa fa-fw fa-pencil"></i> #HtmlEditFormat( translateResource( uri="preside-objects.admin_dashboard:gridlayout.edit.btn" ) )#
+										</a>
+									</li>
+								</cfif>
+								<cfif canClone and Len( cloneLink )>
+									<li>
+										<a href="#HtmlEditFormat( cloneLink )#">
+											<i class="fa fa-fw fa-clone"></i> #HtmlEditFormat( translateResource( uri="preside-objects.admin_dashboard:gridlayout.clone.btn" ) )#
+										</a>
+									</li>
+								</cfif>
+								<cfif canDelete and Len( deleteLink )>
+									<li>
+										<a href="#HtmlEditFormat( deleteLink )#"
+										   class="confirmation-prompt"
+										   title="#HtmlEditFormat( translateResource( uri="preside-objects.admin_dashboard:gridlayout.delete.confirmation", data=[ args.name ?: "" ] ) )#"
+										>
+											<i class="fa fa-fw fa-trash-o"></i> #HtmlEditFormat( translateResource( uri="preside-objects.admin_dashboard:gridlayout.delete.btn" ) )#
+										</a>
+									</li>
+								</cfif>
+							</ul>
+						</div>
+					</cfif>
 				<cfelse>
 					<a class="btn btn-link btn-sm<cfif Len( cancelPrompt )> confirmation-prompt</cfif>" href="#HtmlEditFormat( cancelLink )#"<cfif Len( cancelPrompt )> title="#HtmlEditFormat( cancelPrompt )#"</cfif>>#HtmlEditFormat( cancelBtn )#</a>
 					<a class="btn btn-primary btn-sm js-save-layout" href="#HtmlEditFormat( saveLink )#">#HtmlEditFormat( saveBtn )#</a>

--- a/views/admin/admindashboards/layoutGrid/_inlineDashboardEditToolbar.cfm
+++ b/views/admin/admindashboards/layoutGrid/_inlineDashboardEditToolbar.cfm
@@ -1,0 +1,30 @@
+<cfscript>
+	layoutAction   = LCase( args.dashboardLayoutAction ?: "viewrecord" );
+	showToolbar    = isTrue( args.showInlineDashboardEditToolbar ?: "" );
+	editLink       = args.inlineToolbarEditLink   ?: "";
+	saveLink       = args.inlineToolbarSaveLink   ?: "";
+	cancelLink     = args.inlineToolbarCancelLink ?: "";
+	hasTempWidgets = isTrue( args.inlineToolbarHasTempWidgets ?: "" );
+	cancelPrompt   = hasTempWidgets ? translateResource( uri="preside-objects.admin_dashboard:gridlayout.cancel.confirmation" ) : "";
+	editLayoutBtn  = translateResource( "preside-objects.admin_dashboard:gridlayout.editlayout.btn" );
+	cancelBtn      = translateResource( uri="preside-objects.admin_dashboard:gridlayout.cancel.btn" );
+	saveBtn        = translateResource( uri="preside-objects.admin_dashboard:gridlayout.save.btn" );
+</cfscript>
+
+<cfoutput>
+	<cfif showToolbar>
+		<div class="admin-dashboard-inline-edit-toolbar clearfix">
+			<div class="pull-right btn-toolbar">
+				<cfif layoutAction == "viewrecord">
+					<a class="btn btn-primary btn-sm" href="#HtmlEditFormat( editLink )#">#HtmlEditFormat( editLayoutBtn )#</a>
+				<cfelse>
+					<a class="btn btn-link btn-sm<cfif Len( cancelPrompt )> confirmation-prompt</cfif>" href="#HtmlEditFormat( cancelLink )#"<cfif Len( cancelPrompt )> title="#HtmlEditFormat( cancelPrompt )#"</cfif>>#HtmlEditFormat( cancelBtn )#</a>
+					<a class="btn btn-primary btn-sm js-save-layout" href="#HtmlEditFormat( saveLink )#">#HtmlEditFormat( saveBtn )#</a>
+					<a class="btn btn-default-invert btn-sm js-grid-auto-layout btn-grid-autolayout" href="##" title="">
+						#renderView( view="/admin/admindashboards/layoutGrid/icon-grid-sm" )#
+					</a>
+				</cfif>
+			</div>
+		</div>
+	</cfif>
+</cfoutput>

--- a/views/admin/admindashboards/layoutGrid/_pageTitle.cfm
+++ b/views/admin/admindashboards/layoutGrid/_pageTitle.cfm
@@ -9,7 +9,8 @@
 	hasButtons            = Len( Trim( args.pageHeaderButtons ) );
 	hasIcon               = Len( Trim( args.icon ) );
 	hasCustomImg          = Len( Trim( args.customImg ) );
-	showDashboardSelector = args.showDashboardSelector ?: false;
+	availableDashboards   = args.availableDashboards ?: [];
+	showDashboardSelector = ( args.showDashboardSelector ?: false ) && ( ArrayLen( availableDashboards ) > 0 );
 
 	if( hasCustomImg ) {
 		customImg = event.buildLink( assetId=args.customImg, derivative="customHeaderImg75px" );
@@ -20,7 +21,9 @@
 <cfoutput>
 	<div class="page-header<cfif hasButtons> with-buttons</cfif><cfif hasIcon> with-icon</cfif><cfif hasCustomImg> with-image</cfif>">
 		<div class="page-header-title">
-			<cfif !showDashboardSelector>
+			<cfif isTrue( showDashboardSelector )>
+				#renderView( view="/admin/admindashboards/dashboardSelector/index", args=args )#
+			<cfelse>
 				<h1>
 					<cfif hasIcon>
 						<i class="fa fa-fw #icon#"></i>
@@ -39,8 +42,6 @@
 						</span>
 					</cfif>
 				</h1>
-			<cfelse>
-				#renderView( view="/admin/admindashboards/dashboardSelector/index" )#
 			</cfif>
 		</div>
 		<cfif hasButtons>

--- a/views/admin/admindashboards/layoutGrid/_pageTitle.cfm
+++ b/views/admin/admindashboards/layoutGrid/_pageTitle.cfm
@@ -5,10 +5,11 @@
 	param name="args.pageHeaderButtons" type="string" default="";
 	param name="args.customImg"         type="string" default="";
 
-	icon         = ReFind( "^fa\-", args.icon ) ? args.icon : "fa-#args.icon#";
-	hasButtons   = Len( Trim( args.pageHeaderButtons ) );
-	hasIcon      = Len( Trim( args.icon ) );
-	hasCustomImg = Len( Trim( args.customImg ) );
+	icon                  = ReFind( "^fa\-", args.icon ) ? args.icon : "fa-#args.icon#";
+	hasButtons            = Len( Trim( args.pageHeaderButtons ) );
+	hasIcon               = Len( Trim( args.icon ) );
+	hasCustomImg          = Len( Trim( args.customImg ) );
+	showDashboardSelector = args.showDashboardSelector ?: false;
 
 	if( hasCustomImg ) {
 		customImg = event.buildLink( assetId=args.customImg, derivative="customHeaderImg75px" );
@@ -18,24 +19,30 @@
 
 <cfoutput>
 	<div class="page-header<cfif hasButtons> with-buttons</cfif><cfif hasIcon> with-icon</cfif><cfif hasCustomImg> with-image</cfif>">
-		<h1>
-			<cfif hasIcon>
-				<i class="fa fa-fw #icon#"></i>
-			<cfelseif hasCustomImg>
-				<span class="user-image"><img src="#customImg#" alt=""></span>
-			</cfif>
+		<div class="page-header-title">
+			<cfif !showDashboardSelector>
+				<h1>
+					<cfif hasIcon>
+						<i class="fa fa-fw #icon#"></i>
+					<cfelseif hasCustomImg>
+						<span class="user-image"><img src="#customImg#" alt=""></span>
+					</cfif>
 
-			#args.title#
+					#args.title#
 
-			<cfif Len( Trim( args.subTitle ) )>
-				<span class="sub-title">
-					<small>
-						<i class="fa fa-angle-double-right"></i>
-						<span class="page-subtitle">#args.subTitle#</span>
-					</small>
-				</span>
+					<cfif Len( Trim( args.subTitle ) )>
+						<span class="sub-title">
+							<small>
+								<i class="fa fa-angle-double-right"></i>
+								<span class="page-subtitle">#args.subTitle#</span>
+							</small>
+						</span>
+					</cfif>
+				</h1>
+			<cfelse>
+				#renderView( view="/admin/admindashboards/dashboardSelector/index" )#
 			</cfif>
-		</h1>
+		</div>
 		<cfif hasButtons>
 			<div class="page-header-button-group">
 				#args.pageHeaderButtons#

--- a/views/admin/admindashboards/layoutGrid/_userGenerated.cfm
+++ b/views/admin/admindashboards/layoutGrid/_userGenerated.cfm
@@ -1,17 +1,28 @@
 <cfscript>
-	dashboardId      = args.id           ?: "";
+	dashboardId      = args.dashboardId  ?: args.id ?: "";
 	widgets          = args.widgets      ?: [];
 	canEditDashboard = isTrue( args.canEdit ?: "" );
 
 	addTitle = translateResource( "preside-objects.admin_dashboard:widget.add.btn" );
-	addLink  = event.buildAdminLink( linkTo="adminDashboards.widgetDialog", queryString="dashboard=#dashboardId#" );
+	addQs    = "dashboard=#dashboardId#";
+
+	if ( Len( Trim( args.inlineToolbarPostAddDashboardUrl ?: "" ) ) ) {
+		addQs &= "&post_add_dashboard_url=#UrlEncodedFormat( args.inlineToolbarPostAddDashboardUrl )#";
+	}
+
+	addLink  = event.buildAdminLink( linkTo="adminDashboards.widgetDialog", queryString=addQs );
 
 	event.include( "/js/admin/specific/admindashboards/gridlayout/" )
 		 .include( "/css/admin/specific/admindashboards/gridlayout/" );
 
-	action = LCase( ListLast( rc.event ?: "", "." ) );
-	if ( action != "editdashboardlayout" && action != "viewrecord" ) {
-		action = "viewrecord";
+	action = LCase( args.dashboardLayoutAction ?: "" );
+
+	if ( !Len( action ) ) {
+		action = LCase( ListLast( rc.event ?: "", "." ) );
+
+		if ( action != "editdashboardlayout" && action != "viewrecord" ) {
+			action = "viewrecord";
+		}
 	}
 
 	isViewRecord          = ( action == "viewrecord" );
@@ -22,6 +33,8 @@
 	includePageHeader = isTrue( args.includePageHeader ?:  "" );
 	hasContextData    = isTrue( args.hasContextData ?: "" );
 	nonContextWidgets = args.nonContextWidgets ?: [];
+
+	args.pageHeaderButtons = args.pageHeaderButtons ?: renderView( view="/admin/admindashboards/layoutGrid/_inlineDashboardEditToolbar", args=args );
 </cfscript>
 
 <cfoutput>

--- a/views/admin/admindashboards/layoutGrid/_userGenerated.cfm
+++ b/views/admin/admindashboards/layoutGrid/_userGenerated.cfm
@@ -22,12 +22,13 @@
 <cfoutput>
 	<cfif includePageHeader>
 		#renderView(
-			view="/admin/admindashboards/layoutGrid/_pageTitle"
-			, args={
-				title             = ( prc.pageTitle         ?: "" )
-				, subTitle          = ( prc.pageSubTitle      ?: "" )
-				, icon              = ( prc.pageIcon          ?: "" )
-				, pageHeaderButtons = ( prc.pageHeaderButtons ?: "" )
+			  view = "/admin/admindashboards/layoutGrid/_pageTitle"
+			, args = {
+				  title                 = ( prc.pageTitle             ?: "" )
+				, subTitle              = ( prc.pageSubTitle          ?: "" )
+				, icon                  = ( prc.pageIcon              ?: "" )
+				, pageHeaderButtons     = ( prc.pageHeaderButtons     ?: "" )
+				, showDashboardSelector = ( prc.showDashboardSelector ?: URL.showDashboardSelector ?: false ) // Static way (URL scope), please update accordingly in the proper BE implementation
 			}
 		)#
 	</cfif>

--- a/views/admin/admindashboards/layoutGrid/_userGenerated.cfm
+++ b/views/admin/admindashboards/layoutGrid/_userGenerated.cfm
@@ -10,28 +10,33 @@
 		 .include( "/css/admin/specific/admindashboards/gridlayout/" );
 
 	action = LCase( ListLast( rc.event ?: "", "." ) );
+	if ( action != "editdashboardlayout" && action != "viewrecord" ) {
+		action = "viewrecord";
+	}
 
 	isViewRecord          = ( action == "viewrecord" );
 	isEditDashboardLayout = ( action == "editdashboardlayout" );
 
 	event.includeData( { dashboard_action=action } )
 
-	includePageHeader = IsTrue( args.includePageHeader ?:  "" );
+	includePageHeader = isTrue( args.includePageHeader ?:  "" );
+	hasContextData    = isTrue( args.hasContextData ?: "" );
+	nonContextWidgets = args.nonContextWidgets ?: [];
 </cfscript>
 
 <cfoutput>
-	<cfif includePageHeader>
-		#renderView(
-			  view = "/admin/admindashboards/layoutGrid/_pageTitle"
-			, args = {
-				  title                 = ( prc.pageTitle             ?: "" )
-				, subTitle              = ( prc.pageSubTitle          ?: "" )
-				, icon                  = ( prc.pageIcon              ?: "" )
-				, pageHeaderButtons     = ( prc.pageHeaderButtons     ?: "" )
-				, showDashboardSelector = ( prc.showDashboardSelector ?: URL.showDashboardSelector ?: false ) // Static way (URL scope), please update accordingly in the proper BE implementation
-			}
-		)#
+	<cfif hasContextData and ArrayLen( nonContextWidgets )>
+		<div class="alert alert-warning no-margin-bottom">
+			<p><i class="fa fa-fw fa-exclamation-triangle"></i> #translateResource( uri="admindashboards:non.contextual.widgets.message" )#</p>
+			<ul>
+				<cfloop array="#nonContextWidgets#" item="nonContextWidget">
+					<li>#nonContextWidget.title#</li>
+				</cfloop>
+			</ul>
+		</div>
 	</cfif>
+
+	#renderViewlet( event="admin.adminDashboards.renderDashboardHeader", args=args )#
 
 	<div class="admin-dashboard-container" data-dashboard-id="#dashboardId#">
 

--- a/views/admin/admindashboards/layoutGrid/widgetContainer.cfm
+++ b/views/admin/admindashboards/layoutGrid/widgetContainer.cfm
@@ -26,10 +26,24 @@
 
 	event.includeData( { "#args.instanceId#"=args.contextData } );
 
-	action = ListLast( rc.event ?: "", "." );
+	action = LCase( args.dashboardLayoutAction ?: "" );
+
+	if ( !Len( action ) ) {
+		action = LCase( ListLast( rc.event ?: "", "." ) );
+	}
+
+	if ( action != "editdashboardlayout" && action != "viewrecord" ) {
+		action = "viewrecord";
+	}
 
 	isViewRecord          = ( action == "viewrecord" );
 	isEditDashboardLayout = ( action == "editdashboardlayout" );
+
+	deleteQs = "dashboardId=#args.dashboardId#&instanceId=#args.configInstanceId#";
+
+	if ( Len( Trim( args.deleteWidgetReturnUrl ?: "" ) ) ) {
+		deleteQs &= "&returnUrl=#UrlEncodedFormat( args.deleteWidgetReturnUrl )#";
+	}
 </cfscript>
 
 <cfoutput>
@@ -55,7 +69,7 @@
 							<a class="widget-configuration-link" href="##" title="#HtmlEditFormat( configureTitle )#"><i class="fa fa-fw fa-pencil"></i></a>
 						</cfif>
 						<cfif args.canDeleteWidget>
-							<a class="widget-delete-link" title="#HtmlEditFormat( deletePrompt )#" href="#event.buildAdminLink( linkTo="adminDashboards.deleteWidget", queryString="dashboardId=#args.dashboardId#&instanceId=#args.configInstanceId#" )#"><i class="fa fa-fw fa-trash"></i></a>
+							<a class="widget-delete-link" title="#HtmlEditFormat( deletePrompt )#" href="#event.buildAdminLink( linkTo="adminDashboards.deleteWidget", queryString=deleteQs )#"><i class="fa fa-fw fa-trash"></i></a>
 						</cfif>
 					</cfif>
 				</div>

--- a/views/admin/admindashboards/widget/dashboardDataFilter/render.cfm
+++ b/views/admin/admindashboards/widget/dashboardDataFilter/render.cfm
@@ -1,0 +1,14 @@
+<cfscript>
+	autoCtaLinkUrl = Trim( args.autoCtaLinkUrl ?: "" );
+	tableHtml      = args.tableHtml            ?: "";
+</cfscript>
+
+<cfoutput>
+	<cfif Len( autoCtaLinkUrl )>
+		<a href="#autoCtaLinkUrl#" class="dataviz-single-metric-cta">
+			<i class="fa #translateResource( uri='admin.admindashboards.widget.dashboardDataFilter:widget.cta_link.icon' )#"></i>
+		</a>
+	</cfif>
+
+	#tableHtml#
+</cfoutput>

--- a/views/admin/webflow/adminDashboardsAddWidget/_selectWidgetItems.cfm
+++ b/views/admin/webflow/adminDashboardsAddWidget/_selectWidgetItems.cfm
@@ -23,6 +23,14 @@
 					</div>
 
 					<div class="widget-item-content">
+						<cfif isTrue( availableWidgets.supportContext ?: "" )>
+							<div class="widget-item-precontent">
+								<span class="badge badge-success radius-5">
+									#translateResource( uri="webflow.adminDashboardsAddWidget:step.selectWidget.tag.contextual.label" )#
+								</span>
+							</div>
+						</cfif>
+
 						<p class="widget-item-title">#availableWidgets.title#</p>
 
 						<cfif Len( availableWidgets.description ?: "" )>
@@ -31,15 +39,15 @@
 							</p>
 						</cfif>
 
-						<div class="widget-item-tags">
-							<cfif Len( Trim( availableWidgets.group ?: "" ) )>
+						<cfif Len( Trim( availableWidgets.group ?: "" ) )>
+							<div class="widget-item-tags">
 								<cfloop list="#availableWidgets.group#" item="group">
 									<span class="widget-item-tag">
 										#translateResource( uri="admindashboards:group.#group#.label", defaultValue=UcFirst( group ) )#
 									</span>
 								</cfloop>
-							</cfif>
-						</div>
+							</div>
+						</cfif>
 					</div>
 				</cfif>
 			</label>

--- a/views/admin/webflow/adminDashboardsAddWidget/confirmation.cfm
+++ b/views/admin/webflow/adminDashboardsAddWidget/confirmation.cfm
@@ -1,7 +1,13 @@
 <cfscript>
-	introText   = Trim( args.stepConfig.intro ?: "" );
-	dashboardId = Trim( args.dashboardId      ?: ( rc.dashboard ?: "" ) );
-	buttonUrl   = Len( dashboardId ) ? event.buildAdminLink( objectName="admin_dashboard", operation="editdashboardlayout", recordId=dashboardId ) : ( cgi.http_referer ?: "" );
+	introText    = Trim( args.stepConfig.intro ?: "" );
+	dashboardId  = Trim( args.dashboardId      ?: ( rc.dashboard ?: "" ) );
+	postAddUrl   = Trim( args.post_add_dashboard_url ?: "" );
+	defaultEdit  = Len( dashboardId ) ? event.buildAdminLink( objectName="admin_dashboard", operation="editdashboardlayout", recordId=dashboardId ) : "";
+	buttonUrl    = Len( postAddUrl ) ? postAddUrl : defaultEdit;
+
+	if ( !Len( buttonUrl ) ) {
+		buttonUrl = cgi.http_referer ?: "";
+	}
 </cfscript>
 
 <cfoutput>


### PR DESCRIPTION
- Add dashboard selector static cutup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persistence and sync logic for system dashboards plus new filtering in admin listings; mistakes could hide dashboards or block edits. UI changes are straightforward but rely on new service behavior (context filtering and selector links).
> 
> **Overview**
> Adds **system dashboards** and **dashboard context metadata** to `admin_dashboard` (new `contexts`, `is_system`, `system_id`; `owner` no longer required), including a migration to default `is_system=false`.
> 
> Implements automatic **system dashboard sync** on app start (`AdminDashboardService.syncSystemDashboards()`), treating system dashboards as viewable but not editable/shareable/deletable, and updates admin data manager listing/sidebar to support a dedicated *System dashboards* view with context-based category filtering.
> 
> Introduces a new **dashboard selector** in the page header (`views/admin/admindashboards/dashboardSelector/*` + LESS) and wires it into both standard and user-generated dashboard views via `getDashboardsForSelector()`. Also adds widget “supports contextual display” detection (`isWidgetSupportContext`) surfaced in the add-widget UI and warns when context data is present but some widgets don’t support it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355e5ced8a20e26c342d35ef4a9b707230b57d0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->