### PR TITLE
DASH-76: Widget header missing on collapsed sidebar and overlapping to icon

### DIFF
--- a/assets/css/admin/specific/admindashboards/gridlayout/style.less
+++ b/assets/css/admin/specific/admindashboards/gridlayout/style.less
@@ -100,6 +100,7 @@
 					position        : sticky;
 					top             : 0;
 					z-index         : 1;
+					transform       : translate(0);
 
 					&:before,
 					&:after {
@@ -223,6 +224,13 @@
 							}
 						}
 					}
+				}
+			}
+
+			&:has( .dataviz-single-metric-cta ) {
+				
+				.widget-header > .widget-title {
+					padding-right : 20px;
 				}
 			}
 		}


### PR DESCRIPTION
- Fix widget header missing on collapsed sidebar, and add padding to prevent overlap to icon cta.